### PR TITLE
Fix cron action

### DIFF
--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 12.x
       - name: Install
-        run: npm run install:ci
+        run: npm run install
       - name: Lint
         run: npm run lint
       - name: Test


### PR DESCRIPTION
The github action running all tests in all packages failed because the install command didn't install all the packages: https://github.com/transmute-industries/sidetree.js/runs/1000874923

This PR fixes it