### PR TITLE
Add a new way to pass AWS credentials in constructors

### DIFF
--- a/packages/cas-s3/src/S3Cas.spec.ts
+++ b/packages/cas-s3/src/S3Cas.spec.ts
@@ -19,6 +19,16 @@
 
 import { testSuite } from '@sidetree/cas';
 import S3Cas from './S3Cas';
+import AWS from 'aws-sdk';
+
+const config = new AWS.Config();
+if (!config.credentials) {
+  console.warn(
+    'No AWS credentials found in ~/.aws/credentials, skipping QLDB tests...'
+  );
+  // eslint-disable-next-line no-global-assign
+  describe = describe.skip;
+}
 
 const cas = new S3Cas('sidetree-cas-s3-test');
 

--- a/packages/cas-s3/src/S3Cas.ts
+++ b/packages/cas-s3/src/S3Cas.ts
@@ -26,18 +26,24 @@ import {
 import Unixfs from 'ipfs-unixfs';
 import { DAGNode } from 'ipld-dag-pb';
 import AWS from 'aws-sdk';
+import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 const { version } = require('../package.json');
-
-const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 /**
  * Implementation of a CAS class for testing.
  * Simply using a hash map to store all the content by hash.
  */
 export default class S3Cas implements ICas {
-  constructor(private bucketName: string) {
+  private s3: AWS.S3;
+
+  constructor(private bucketName: string, config?: CredentialsOptions) {
     if (!this.bucketName) {
       throw new Error('You must specify a bucketName');
+    }
+    if (config) {
+      this.s3 = new AWS.S3({ ...config });
+    } else {
+      this.s3 = new AWS.S3();
     }
   }
 
@@ -52,7 +58,7 @@ export default class S3Cas implements ICas {
     const bucketParams = {
       Bucket: this.bucketName,
     };
-    await s3.createBucket(bucketParams).promise();
+    await this.s3.createBucket(bucketParams).promise();
   }
 
   async close(): Promise<void> {
@@ -74,7 +80,7 @@ export default class S3Cas implements ICas {
 
   public async write(content: Buffer): Promise<string> {
     const encodedHash = await S3Cas.getAddress(content);
-    const writeResult = await s3
+    const writeResult = await this.s3
       .upload({
         Bucket: this.bucketName,
         Key: encodedHash,
@@ -88,7 +94,7 @@ export default class S3Cas implements ICas {
 
   public async read(address: string): Promise<FetchResult> {
     try {
-      const readResult = await s3
+      const readResult = await this.s3
         .getObject({
           Bucket: 'sidetree-cas-s3-test',
           Key: address,


### PR DESCRIPTION
- feat: allow to pass aws config in QLDB constructor
- feat: allow to pass aws config in cas-s3 constructor
- test: skip s3 tests if no aws credentials are found 

Now there is two ways to provide AWS credentials:
- having the default aws credentials configured in ~/.aws/credentials
- passing the credentials in the constructor