### PR TITLE
Fix qldb interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,22 @@ To install all packages run
 npm install
 ```
 
+To install a specific package (and its dependencies) run
+
+```bash
+npm run install:only @sidetree/photon
+```
+
 To run tests in every packages run
 
 ```bash
 npm run test
 ```
 
-To run tests in a specific package run
+To test a specific package run
 
 ```bash
-npm t -- --scope @sidetree/did-method-element
+npm run test:only @sidetree/photon
 ```
 
 ## Services

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "clean:lock": "npx lerna exec 'rm -rf package-lock.json node_modules'",
     "postinstall": "lerna bootstrap",
+    "install:only": "lerna bootstrap --include-dependencies --scope",
     "lint": "lerna run lint --stream",
     "lint:fix": "lerna run lint:fix --stream",
     "test": "lerna run test --stream --concurrency 1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "lerna run lint --stream",
     "lint:fix": "lerna run lint:fix --stream",
     "test": "lerna run test --stream --concurrency 1",
+    "test:only": "npm t -- --scope",
     "build": "lerna run build --stream",
     "install:ci": "npm install --ignore-scripts && lerna link && lerna bootstrap --since origin/main --include-dependencies",
     "install:clean": "npx lerna clean -y && rm -rf node_modules && npm i",

--- a/packages/cas-s3/src/S3Cas.spec.ts
+++ b/packages/cas-s3/src/S3Cas.spec.ts
@@ -19,7 +19,8 @@
 
 import { testSuite } from '@sidetree/cas';
 import S3Cas from './S3Cas';
-import AWS from 'aws-sdk';
+// import AWS object without services
+import AWS from 'aws-sdk/global';
 
 const config = new AWS.Config();
 if (!config.credentials) {

--- a/packages/cas-s3/src/S3Cas.ts
+++ b/packages/cas-s3/src/S3Cas.ts
@@ -25,7 +25,7 @@ import {
 } from '@sidetree/common';
 import Unixfs from 'ipfs-unixfs';
 import { DAGNode } from 'ipld-dag-pb';
-import AWS from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
 import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 const { version } = require('../package.json');
 
@@ -34,17 +34,17 @@ const { version } = require('../package.json');
  * Simply using a hash map to store all the content by hash.
  */
 export default class S3Cas implements ICas {
-  private s3: AWS.S3;
+  private s3: S3;
 
   constructor(private bucketName: string, config?: CredentialsOptions) {
     if (!this.bucketName) {
       throw new Error('You must specify a bucketName');
     }
     if (config) {
-      this.s3 = new AWS.S3({ ...config });
+      this.s3 = new S3({ ...config });
     } else {
       // Load AWS credentials from ~/.aws/credentials file
-      this.s3 = new AWS.S3();
+      this.s3 = new S3();
     }
   }
 

--- a/packages/did-method-photon/src/test/Photon.test.ts
+++ b/packages/did-method-photon/src/test/Photon.test.ts
@@ -23,7 +23,7 @@ import {
 } from './utils';
 import Photon from '../Photon';
 import config from './photon-config.json';
-import AWS from 'aws-sdk';
+import AWS from 'aws-sdk/global';
 
 const awsConfig = new AWS.Config();
 if (!awsConfig.credentials) {

--- a/packages/ledger-qldb/package-lock.json
+++ b/packages/ledger-qldb/package-lock.json
@@ -1585,9 +1585,9 @@
 			}
 		},
 		"amazon-qldb-driver-nodejs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-2.0.0.tgz",
-			"integrity": "sha512-RISPNNq00ggc1I8BCuNypvmqPXds+cPIw3Rim60UISE7Xx16prtBKOPe0EV2zM1STGVdYGtIDIoyGswGGvuXzA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-2.1.0.tgz",
+			"integrity": "sha512-yqKFa+KGAabYfOdKNSq8xisOyj0N3SKLzTi3heXOvYbeVheBW7r/r9PSrcYKAqTAWx4mIOmyz7Xd+jbpT3c7Nw==",
 			"requires": {
 				"@types/node": "12.0.2",
 				"ion-hash-js": "2.0.0",
@@ -1777,9 +1777,9 @@
 			"dev": true
 		},
 		"aws-sdk": {
-			"version": "2.760.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.760.0.tgz",
-			"integrity": "sha512-u1DhOXbN8/yLRaJ2sjY2ZmjiwEPl4KuGKafaM4oJXzEyOPo5Kwtvau62FgqeRSBVxkw9sipuA5sfYxdwLbq6vg==",
+			"version": "2.828.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.828.0.tgz",
+			"integrity": "sha512-JoDujGdncSIF9ka+XFZjop/7G+fNGucwPwYj7OHYMmFIOV5p7YmqomdbVmH/vIzd988YZz8oLOinWc4jM6vvhg==",
 			"requires": {
 				"buffer": "4.9.2",
 				"events": "1.1.1",
@@ -2164,9 +2164,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -4342,9 +4342,9 @@
 			"integrity": "sha512-5E9YmRhxn1XGv/qftwqma1iTM0fWgfLbH8qWf6OCHIGppft7uQ+ClUkI5swNB4n9IDZ7GL0rFHINW2oPrurr5Q=="
 		},
 		"ion-js": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/ion-js/-/ion-js-4.0.1.tgz",
-			"integrity": "sha512-MXZIzjkCXNCf8p37sToxQ2Capn1+TFYS9QRVY6VZKGH7B3lop0gyvkh/eLGABdzvsI6xd9M/Yd6zdIhlBAkmCw=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ion-js/-/ion-js-4.1.0.tgz",
+			"integrity": "sha512-uxkF1g0DAPqCdWHzSH6z8KYcMmDZBbwVboltNMioXwZmbaB+ZvnXQtrzUjlxts1nKIUok6b8mC6HIh36GbJQbw=="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",

--- a/packages/ledger-qldb/package-lock.json
+++ b/packages/ledger-qldb/package-lock.json
@@ -5776,6 +5776,11 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"moment": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+		},
 		"mri": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",

--- a/packages/ledger-qldb/package.json
+++ b/packages/ledger-qldb/package.json
@@ -33,6 +33,7 @@
     "amazon-qldb-driver-nodejs": "^2.1.0",
     "aws-sdk": "^2.828.0",
     "ion-js": "^4.1.0",
-    "jsbi": "^3.1.4"
+    "jsbi": "^3.1.4",
+    "moment": "^2.29.1"
   }
 }

--- a/packages/ledger-qldb/package.json
+++ b/packages/ledger-qldb/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@sidetree/common": "^0.2.1",
-    "amazon-qldb-driver-nodejs": "^2.0.0",
-    "aws-sdk": "^2.751.0",
-    "ion-js": "^4.0.1",
+    "amazon-qldb-driver-nodejs": "^2.1.0",
+    "aws-sdk": "^2.828.0",
+    "ion-js": "^4.1.0",
     "jsbi": "^3.1.4"
   }
 }

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -207,12 +207,12 @@ export default class QLDBLedger implements IBlockchain {
     hash: '',
   };
 
+  // Getting the latest block is a very costly operation in QLDB (requires a full table scan)
+  // Moreover getLatestTime is only used in VersionManager and to detect block reorgs
+  // Currently we only support one version in VersionManager, and there is no block reorgs in QLDB
+  // Therefore we can get away with only returning the initial approximate time
   public async getLatestTime(): Promise<BlockchainTimeModel> {
-    const transactionCount = await this.getTransactionCount();
-    if (transactionCount > 0) {
-      const latestTime = transactionCount - 1;
-      this.approximateTime.time = latestTime;
-    }
+    console.warn('getLatestTime is not implemented in QLDB');
     return this.approximateTime;
   }
 

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -156,10 +156,16 @@ export default class QLDBLedger implements IBlockchain {
   }> {
     let result;
     if (sinceTransactionNumber) {
+      console.warn(
+        'reading since transactionNumber is a costly operation (full table scan), use with caution'
+      );
       result = await this.executeWithRetry(
         `SELECT * FROM _ql_committed_${this.transactionTable} as R WHERE R.blockAddress.sequenceNo >= ${sinceTransactionNumber}`
       );
     } else if (transactionTimeHash) {
+      console.warn(
+        'reading all transactions is a costly operation (full table scan), use with caution'
+      );
       result = await this.executeWithRetry(
         `SELECT * FROM _ql_committed_${this.transactionTable} BY doc_id WHERE doc_id = '${transactionTimeHash}'`
       );
@@ -196,6 +202,9 @@ export default class QLDBLedger implements IBlockchain {
 
   // Getting the latest block is a very costly operation in QLDB
   public async getLatestTime(): Promise<BlockchainTimeModel> {
+    console.warn(
+      'getLatestTime is a costly operation (full table scan), use with caution'
+    );
     const currentDate = moment().format();
     const result = await this.executeWithRetry(
       `SELECT blockAddress, id FROM history(${this.transactionTable}, \`${currentDate}\`) AS h BY id`

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -178,8 +178,8 @@ export default class QLDBLedger implements IBlockchain {
     const transactions: TransactionModel[] = (resultList as ValueWithMetaData[]).map(
       this.toSidetreeTransaction
     );
-    // Sort by increasing order of transaction number
-    // TODO: Sort with PartiQL ?
+    // PartiQL does not support returning sorted data
+    // so we have to sort in javascript
     transactions.sort((t1, t2) => {
       return t1.transactionNumber - t2.transactionNumber;
     });

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { QldbDriver, RetryConfig, Result } from 'amazon-qldb-driver-nodejs';
-import { dom } from 'ion-js';
 import {
   AnchoredDataSerializer,
   BlockchainTimeModel,
@@ -13,11 +12,7 @@ import { Timestamp } from 'aws-sdk/clients/apigateway';
 import QLDBSession from 'aws-sdk/clients/qldbsession';
 const { version } = require('../package.json');
 
-interface ValueWithCount extends dom.Value {
-  transactionCount: number;
-}
-
-interface ValueWithMetaData extends dom.Value {
+interface ValueWithMetaData {
   blockAddress: {
     sequenceNo: number;
   };
@@ -117,9 +112,7 @@ export default class QLDBLedger implements IBlockchain {
       `SELECT COUNT(*) AS transactionCount FROM ${this.transactionTable}`
     );
     const resultList = (result as Result).getResultList();
-    const transactionCount = Number(
-      (resultList[0] as ValueWithCount).transactionCount
-    );
+    const transactionCount = Number((resultList[0] as any).transactionCount);
     return transactionCount;
   }
 

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -103,9 +103,6 @@ export default class QLDBLedger implements IBlockchain {
 
   public async initialize(): Promise<void> {
     await this.executeWithoutError(`CREATE TABLE ${this.transactionTable}`);
-    await this.executeWithoutError(
-      `CREATE INDEX ON ${this.transactionTable} (transactionNumber)`
-    );
   }
 
   private async getTransactionCount(): Promise<number> {

--- a/packages/ledger-qldb/src/test/QLDBLedger.test.ts
+++ b/packages/ledger-qldb/src/test/QLDBLedger.test.ts
@@ -14,7 +14,7 @@
 
 import { testSuite } from '@sidetree/ledger';
 import QLDBLedger from '..';
-import AWS from 'aws-sdk';
+import AWS from 'aws-sdk/global';
 
 jest.setTimeout(10 * 1000);
 

--- a/packages/ledger/src/__tests__/testSuite.ts
+++ b/packages/ledger/src/__tests__/testSuite.ts
@@ -57,7 +57,7 @@ const testSuite = (ledger: IBlockchain): void => {
         const readResult = await ledger.read();
         expect(readResult.moreTransactions).toBeFalsy();
         expect(readResult.transactions).toHaveLength(1);
-        expect(readResult.transactions[0].transactionNumber).toBe(0);
+        expect(readResult.transactions[0].transactionNumber).toBeDefined();
         expect(readResult.transactions[0].transactionTime).toBeDefined();
         expect(readResult.transactions[0].transactionTimeHash).toBeDefined();
         expect(readResult.transactions[0].anchorString).toBe(anchorString);
@@ -88,18 +88,18 @@ const testSuite = (ledger: IBlockchain): void => {
         const readResult = await ledger.read(sinceTransactionNumber);
         expect(readResult.moreTransactions).toBeFalsy();
         expect(readResult.transactions).toHaveLength(2);
-        expect(readResult.transactions[0].transactionNumber).toBe(
-          sinceTransactionNumber
-        );
-        expect(readResult.transactions[1].transactionNumber).toBe(
-          sinceTransactionNumber + 1
-        );
+        expect(
+          readResult.transactions[0].transactionNumber
+        ).toBeGreaterThanOrEqual(sinceTransactionNumber);
+        expect(
+          readResult.transactions[1].transactionNumber
+        ).toBeGreaterThanOrEqual(readResult.transactions[0].transactionNumber);
         expect(readResult.transactions[0].anchorString).toBe(anchorString2);
         expect(readResult.transactions[1].anchorString).toBe(anchorString3);
       });
 
-      it('should return no transaction if the requested transactionNumber doesnt exist', async () => {
-        const readResult = await ledger.read(3);
+      it('should return no transaction if the requested transactionNumber has not been reached', async () => {
+        const readResult = await ledger.read(Number.MAX_SAFE_INTEGER);
         expect(readResult.moreTransactions).toBeFalsy();
         expect(readResult.transactions).toHaveLength(0);
       });

--- a/packages/ledger/src/__tests__/testSuite.ts
+++ b/packages/ledger/src/__tests__/testSuite.ts
@@ -99,7 +99,7 @@ const testSuite = (ledger: IBlockchain): void => {
       });
 
       it('should return no transaction if the requested transactionNumber has not been reached', async () => {
-        const readResult = await ledger.read(Number.MAX_SAFE_INTEGER);
+        const readResult = await ledger.read(Number.MAX_SAFE_INTEGER - 1);
         expect(readResult.moreTransactions).toBeFalsy();
         expect(readResult.transactions).toHaveLength(0);
       });


### PR DESCRIPTION
- Add `install:only` and `test:only` commands + documentation
- Fix AWS imports to reduce build times

## Update to QLDB ledger
- Use document `id` instead of block hash to perform efficient queries of a specific transaction
- Remove `transactionNumber` property, use `blockAddress.sequenceNo` instead
- Remove unused index on `transactionNumber`
- Update `getLatestTime` to use `HISTORY` function
- Add warnings when using methods that perform full table scans
- Update ledger test suite