### PR TITLE
Add test for batching

### DIFF
--- a/packages/common/src/util/parameters.ts
+++ b/packages/common/src/util/parameters.ts
@@ -28,7 +28,7 @@ const protocolParameters: ProtocolParameters = {
   maxChunkFileSizeInBytes: 20000000,
   maxDeltaSizeInBytes: 1000,
   maxMapFileSizeInBytes: 1000000,
-  maxNumberOfOperationsForNoValueTimeLock: 100,
+  maxNumberOfOperationsForNoValueTimeLock: 10000,
   maxNumberOfOperationsPerTransactionTime: 600000,
   maxNumberOfTransactionsPerTransactionTime: 300,
   maxOperationsPerBatch: 10000,

--- a/packages/common/src/util/parameters.ts
+++ b/packages/common/src/util/parameters.ts
@@ -28,10 +28,12 @@ const protocolParameters: ProtocolParameters = {
   maxChunkFileSizeInBytes: 20000000,
   maxDeltaSizeInBytes: 1000,
   maxMapFileSizeInBytes: 1000000,
-  maxNumberOfOperationsForNoValueTimeLock: 10000,
   maxNumberOfOperationsPerTransactionTime: 600000,
   maxNumberOfTransactionsPerTransactionTime: 300,
-  maxOperationsPerBatch: 10000,
+  // If you are not using value lock, maxNumberOfOperationsForNoValueTimeLock
+  // maxOperationsPerBatch should be the same
+  maxNumberOfOperationsForNoValueTimeLock: 1000,
+  maxOperationsPerBatch: 1000,
   normalizedFeeToPerOperationFeeMultiplier: 0.01,
   valueTimeLockAmountMultiplier: 600,
 };

--- a/packages/core/src/test/RequestHandler.spec.ts
+++ b/packages/core/src/test/RequestHandler.spec.ts
@@ -61,7 +61,7 @@ const util = require('util');
 
 describe('RequestHandler', () => {
   // Surpress console logging during dtesting so we get a compact test summary in console.
-  console.info = () => null;
+  console.info = (): null => null;
   console.error = () => null;
   console.debug = () => null;
 

--- a/packages/core/src/test/TransactionProcessor.spec.ts
+++ b/packages/core/src/test/TransactionProcessor.spec.ts
@@ -44,7 +44,7 @@ import config from './config-test.json';
 
 jest.setTimeout(10 * 1000);
 
-console.info = () => null;
+console.info = (): null => null;
 
 describe('TransactionProcessor', () => {
   let casClient: MockCas;

--- a/packages/core/src/test/ValueTimeLockVerifier.spec.ts
+++ b/packages/core/src/test/ValueTimeLockVerifier.spec.ts
@@ -193,7 +193,7 @@ describe('ValueTimeLockVerifier', () => {
     });
 
     it('should throw if the lock amount is less than the required amount.', () => {
-      const mockMaxNumOfOps = 23400;
+      const mockMaxNumOfOps = 2340;
       spyOn(
         ValueTimeLockVerifier,
         'calculateMaxNumberOfOperationsAllowed'

--- a/packages/core/src/test/ValueTimeLockVerifier.spec.ts
+++ b/packages/core/src/test/ValueTimeLockVerifier.spec.ts
@@ -193,7 +193,7 @@ describe('ValueTimeLockVerifier', () => {
     });
 
     it('should throw if the lock amount is less than the required amount.', () => {
-      const mockMaxNumOfOps = 234;
+      const mockMaxNumOfOps = 23400;
       spyOn(
         ValueTimeLockVerifier,
         'calculateMaxNumberOfOperationsAllowed'

--- a/packages/core/src/test/ietf-patch-operations.spec.ts
+++ b/packages/core/src/test/ietf-patch-operations.spec.ts
@@ -29,7 +29,7 @@ import Resolver from '../Resolver';
 import MockOperationStore from './mocks/MockOperationStore';
 import MockVersionManager from './mocks/MockVersionManager';
 
-console.info = () => null;
+console.info = (): null => null;
 
 describe('IETF Patch operations', () => {
   let resolver: Resolver;

--- a/packages/core/src/test/write/BatchScheduler.spec.ts
+++ b/packages/core/src/test/write/BatchScheduler.spec.ts
@@ -23,7 +23,7 @@ import MockBatchWriter from '../mocks/MockBatchWriter';
 import { MockLedger } from '@sidetree/ledger';
 import MockVersionManager from '../mocks/MockVersionManager';
 
-console.info = () => null;
+console.info = (): null => null;
 
 describe('BatchScheduler', () => {
   it('should periodically invoke batch writer.', async () => {

--- a/packages/did-method-element/src/Element.spec.ts
+++ b/packages/did-method-element/src/Element.spec.ts
@@ -19,7 +19,7 @@ import { testVectors } from '@sidetree/test-vectors';
 import { resetDatabase, getTestLedger, getTestCas } from './test/utils';
 import config from './test/element-config.json';
 
-console.info = () => null;
+console.info = (): null => null;
 
 describe('Element', () => {
   let ledger: EthereumLedger;

--- a/packages/did-method-element/src/__test__/dif-test-vector-conformance.spec.ts
+++ b/packages/did-method-element/src/__test__/dif-test-vector-conformance.spec.ts
@@ -16,7 +16,7 @@ import Element from '../Element';
 import { testVectors } from '@sidetree/test-vectors';
 import { getTestElement, replaceMethod } from '../test/utils';
 
-console.info = () => null;
+console.info = (): null => null;
 
 let element: Element;
 

--- a/packages/did-method-element/src/__test__/generate-universal-wallet-fixture.test.ts
+++ b/packages/did-method-element/src/__test__/generate-universal-wallet-fixture.test.ts
@@ -13,14 +13,11 @@
  */
 
 import { sidetreeUniversalWallet } from '@sidetree/test-vectors';
-
 import Element from '../Element';
-
 import { getTestElement, resetDatabase, writeFixture } from '../test/utils';
-
 import { walletResolution } from '../__fixtures__';
 
-console.info = () => null;
+console.info = (): null => null;
 
 const { walletOperation } = sidetreeUniversalWallet;
 

--- a/packages/did-method-element/src/__test__/sidetree-core-generated-ed25519-conformance.test.ts
+++ b/packages/did-method-element/src/__test__/sidetree-core-generated-ed25519-conformance.test.ts
@@ -13,13 +13,11 @@
  */
 
 import Element from '../Element';
-
 import { sidetreeCoreGeneratedEd25519Resolutions } from '../__fixtures__';
 import { sidetreeCoreGeneratedEd25519 } from '@sidetree/test-vectors';
-
 import { getTestElement } from '../test/utils';
 
-console.info = () => null;
+console.info = (): null => null;
 
 let element: Element;
 

--- a/packages/did-method-element/src/__test__/sidetree-core-generated-filesystem-conformance.test.ts
+++ b/packages/did-method-element/src/__test__/sidetree-core-generated-filesystem-conformance.test.ts
@@ -15,12 +15,10 @@
 import { MockCas } from '@sidetree/cas';
 import { AnchorFile, ChunkFile, MapFile } from '@sidetree/core';
 import Element from '../Element';
-
 import { getTestElement } from '../test/utils';
-
 import { sidetreeCoreGeneratedSecp256k1 } from '@sidetree/test-vectors';
 
-console.info = () => null;
+console.info = (): null => null;
 
 let element: Element;
 

--- a/packages/did-method-element/src/__test__/sidetree-core-generated-secp256k1-conformance.test.ts
+++ b/packages/did-method-element/src/__test__/sidetree-core-generated-secp256k1-conformance.test.ts
@@ -13,13 +13,11 @@
  */
 
 import Element from '../Element';
-
 import { sidetreeCoreGeneratedSecp256k1Resolutions } from '../__fixtures__';
 import { sidetreeCoreGeneratedSecp256k1 } from '@sidetree/test-vectors';
-
 import { getTestElement } from '../test/utils';
 
-console.info = () => null;
+console.info = (): null => null;
 
 let element: Element;
 

--- a/packages/did-method-element/src/__test__/sidetree-wallet-svip-profile-conformance.test.ts
+++ b/packages/did-method-element/src/__test__/sidetree-wallet-svip-profile-conformance.test.ts
@@ -15,12 +15,11 @@
 import Element from '../Element';
 import { walletSvipResolutions } from '../__fixtures__';
 import { getTestElement, resetDatabase, writeFixture } from '../test/utils';
-
 import { sidetreeUniversalWallet } from '@sidetree/test-vectors';
 
 const { walletSvipOperation } = sidetreeUniversalWallet;
 const WRITE_FIXTURE_TO_DISK = false;
-console.info = () => null;
+console.info = (): null => null;
 
 let element: Element;
 const fixture: any = {

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -26,6 +26,7 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
+    "@sidetree/wallet": "^0.2.2",
     "aws-sdk": "^2.763.0",
     "tsdx": "^0.13.3"
   },

--- a/packages/did-method-photon/src/test/Photon.test.ts
+++ b/packages/did-method-photon/src/test/Photon.test.ts
@@ -58,7 +58,6 @@ describe('Photon', () => {
     await resetDatabase();
     ledger = await getTestLedger();
     cas = await getTestCas();
-    await ledger.reset();
   });
 
   afterAll(async () => {

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -14,10 +14,10 @@
 
 import { methods } from '@sidetree/wallet';
 import { crypto } from '@sidetree/test-vectors';
-import { MongoDbOperationQueue } from '@sidetree/db';
 import { getTestPhoton } from './utils';
 import Photon from '../Photon';
 import AWS from 'aws-sdk/global';
+import { IOperationQueue } from '@sidetree/common';
 
 const awsConfig = new AWS.Config();
 if (!awsConfig.credentials) {
@@ -34,11 +34,11 @@ jest.setTimeout(10 * 1000);
 
 describe('Photon', () => {
   let photon: Photon;
-  let operationQueue: MongoDbOperationQueue;
+  let operationQueue: IOperationQueue;
 
   beforeAll(async () => {
     photon = await getTestPhoton();
-    const { versionManager } = photon as any;
+    const { versionManager } = photon;
     operationQueue = versionManager.getOperationQueue(
       photon.blockchain.approximateTime.time
     );

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -107,7 +107,9 @@ describe('Photon', () => {
   runBatchingTestWithSize(10);
   runBatchingTestWithSize(100);
   // Running a batch of size 1000 and 10000 works but the first test that
-  // generates the batch times out.
+  // generates the batch times out. However the "trigger batch" and
+  // "resolve dids" tests are passing under 10 seconds which is what we wanted
+  // to know.
   // Uncomment and increase the jest.setTimeout value to find out
   // runBatchingTestWithSize(1000);
   // runBatchingTestWithSize(10000);

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -43,10 +43,10 @@ describe('Photon', () => {
   });
 
   const batchSize = 10;
+  const batch: any[] = [];
 
   it(`should generate a batch of ${batchSize} credentials`, async () => {
     const mnemonic = crypto.mnemonic.mnemonic[0];
-    const batch = [];
     for (let i = 0; i < batchSize; i++) {
       const createOperation = await methods.getCreateOperationForProfile(
         mnemonic,
@@ -55,5 +55,17 @@ describe('Photon', () => {
       batch.push(createOperation);
     }
     expect(batch).toHaveLength(batchSize);
+  });
+
+  it('should submit these operations to the queue', async () => {
+    for (let i = 0; i < batchSize; i++) {
+      const operation = await photon.handleOperationRequest(
+        Buffer.from(JSON.stringify(batch[i]))
+      );
+      expect(operation.status).toBe('succeeded');
+      expect(operation.body).toBeDefined();
+      const { didDocument } = operation.body;
+      expect(didDocument).toBeDefined();
+    }
   });
 });

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 - Transmute Industries Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { methods } from '@sidetree/wallet';
+import { crypto } from '@sidetree/test-vectors';
+import { getTestPhoton } from './utils';
+import Photon from '../Photon';
+import AWS from 'aws-sdk/global';
+
+const awsConfig = new AWS.Config();
+if (!awsConfig.credentials) {
+  console.warn(
+    'No AWS credentials found in ~/.aws/credentials, skipping Photon tests...'
+  );
+  // eslint-disable-next-line no-global-assign
+  describe = describe.skip;
+}
+
+console.info = (): null => null;
+
+jest.setTimeout(30 * 1000);
+
+describe('Photon', () => {
+  let photon: Photon;
+
+  beforeAll(async () => {
+    photon = await getTestPhoton();
+  });
+
+  afterAll(async () => {
+    await photon.close();
+  });
+
+  const batchSize = 10;
+
+  it(`should generate a batch of ${batchSize} credentials`, async () => {
+    const mnemonic = crypto.mnemonic.mnemonic[0];
+    const batch = [];
+    for (let i = 0; i < batchSize; i++) {
+      const createOperation = await methods.getCreateOperationForProfile(
+        mnemonic,
+        i
+      );
+      batch.push(createOperation);
+    }
+    expect(batch).toHaveLength(batchSize);
+  });
+});

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -14,10 +14,10 @@
 
 import { methods } from '@sidetree/wallet';
 import { crypto } from '@sidetree/test-vectors';
-import { getTestPhoton } from './utils';
+import { getTestPhoton, generateCreateOperation } from './utils';
 import Photon from '../Photon';
 import AWS from 'aws-sdk/global';
-import { IOperationQueue, PublicKeyPurpose } from '@sidetree/common';
+import { IOperationQueue } from '@sidetree/common';
 
 const awsConfig = new AWS.Config();
 if (!awsConfig.credentials) {
@@ -47,39 +47,6 @@ describe('Test Batching', () => {
   afterAll(async () => {
     await photon.close();
   });
-
-  const generateCreateOperation = async (publicKey: any): Promise<any> => {
-    // We could generate the create operation like this
-    /*
-    const mnemonic = crypto.mnemonic.mnemonic[0];
-    const createOperation = await methods.getCreateOperationForProfile(
-      mnemonic,
-      i
-    );
-    */
-    // However this is too slow because it generates new keys for every create
-    // operation which cause the tests to timeout for batch size larger than 1000
-
-    // Therefore for the purpose of showing the we can process large batches
-    // we will generate create operation for did documents that share the same key
-    const documentModel = {
-      public_keys: [
-        {
-          // id is random so that each id (and therefore each did) is different
-          id: Math.random(),
-          type: 'JsonWebKey2020',
-          jwk: publicKey,
-          purpose: [PublicKeyPurpose.General],
-        },
-      ],
-    };
-    const createOperation = await methods.getCreatePayloadFromDocumentModel(
-      documentModel,
-      publicKey,
-      publicKey
-    );
-    return createOperation;
-  };
 
   const runBatchingTestWithSize = (batchSize: number): void => {
     describe(`Batch size: ${batchSize}`, () => {

--- a/packages/did-method-photon/src/test/batch.test.ts
+++ b/packages/did-method-photon/src/test/batch.test.ts
@@ -30,7 +30,7 @@ if (!awsConfig.credentials) {
 
 console.info = (): null => null;
 
-jest.setTimeout(30 * 1000);
+jest.setTimeout(10 * 1000);
 
 describe('Photon', () => {
   let photon: Photon;
@@ -106,4 +106,9 @@ describe('Photon', () => {
   runBatchingTestWithSize(1);
   runBatchingTestWithSize(10);
   runBatchingTestWithSize(100);
+  // Running a batch of size 1000 and 10000 works but the first test that
+  // generates the batch times out.
+  // Uncomment and increase the jest.setTimeout value to find out
+  // runBatchingTestWithSize(1000);
+  // runBatchingTestWithSize(10000);
 });

--- a/packages/did-method-photon/src/test/utils.ts
+++ b/packages/did-method-photon/src/test/utils.ts
@@ -28,6 +28,7 @@ const resetDatabase = async (): Promise<void> => {
 
 const getTestLedger = async (): Promise<QLDBLedger> => {
   const ledger = new QLDBLedger(config.qldbLedger, config.qldbLedgerTable);
+  await ledger.reset();
   return ledger;
 };
 

--- a/packages/did-method/src/DidMethod.ts
+++ b/packages/did-method/src/DidMethod.ts
@@ -43,7 +43,7 @@ export default class DidMethod {
   public transactionStore: MongoDbTransactionStore;
   private unresolvableTransactionStore: MongoDbUnresolvableTransactionStore;
   public operationStore: MongoDbOperationStore;
-  private versionManager: VersionManager;
+  public versionManager: VersionManager;
   public blockchain: IBlockchain;
   private cas: ICas;
   private downloadManager: DownloadManager;

--- a/packages/wallet/package-lock.json
+++ b/packages/wallet/package-lock.json
@@ -4225,6 +4225,11 @@
 			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
+		"fast-json-patch": {
+			"version": "3.0.0-1",
+			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+			"integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",

--- a/packages/wallet/package-lock.json
+++ b/packages/wallet/package-lock.json
@@ -4225,11 +4225,6 @@
 			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
-		"fast-json-patch": {
-			"version": "3.0.0-1",
-			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
-			"integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
-		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -40,7 +40,6 @@
     "bip39": "^3.0.2",
     "canonicalize": "^1.0.3",
     "factory.ts": "^0.5.1",
-    "fast-json-patch": "^3.0.0-1",
     "hdkey": "^2.0.1",
     "multihashes": "^3.0.1"
   },

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -40,6 +40,7 @@
     "bip39": "^3.0.2",
     "canonicalize": "^1.0.3",
     "factory.ts": "^0.5.1",
+    "fast-json-patch": "^3.0.0-1",
     "hdkey": "^2.0.1",
     "multihashes": "^3.0.1"
   },

--- a/packages/wallet/src/functions/getCreateOperationForProfile.test.ts
+++ b/packages/wallet/src/functions/getCreateOperationForProfile.test.ts
@@ -12,7 +12,6 @@
  */
 
 import { walletSvipOperation } from '../__fixtures__';
-
 import { getCreateOperationForProfile } from './getCreateOperationForProfile';
 
 it('can get create operation from mnemonic', async () => {

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.test.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 - Transmute Industries Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PublicKeyPurpose } from '@sidetree/common';
+import { walletSvipOperation } from '../__fixtures__';
+import { getCreatePayloadFromDocumentModel } from './getCreatePayloadFromDocumentModel';
+import { toKeyPair } from './toKeyPair';
+
+it('can get create operation from mnemonic', async () => {
+  const mnemonic = walletSvipOperation.operation[0].mnemonic;
+  const signingKeyPair = await toKeyPair(mnemonic, 0, 'Ed25519');
+  const keyAgreementKeyPair = await toKeyPair(mnemonic, 0, 'X25519');
+  const documentModel = {
+    public_keys: [
+      {
+        id: signingKeyPair.id.split('#').pop(),
+        type: 'JsonWebKey2020',
+        jwk: signingKeyPair.publicKeyJwk,
+        purpose: [
+          PublicKeyPurpose.General,
+          PublicKeyPurpose.Auth,
+          PublicKeyPurpose.AssertionMethod,
+          PublicKeyPurpose.CapabilityInvocation,
+          PublicKeyPurpose.CapabilityDelegation,
+        ],
+      },
+      {
+        id: keyAgreementKeyPair.id.split('#').pop(),
+        type: 'JsonWebKey2020',
+        jwk: keyAgreementKeyPair.publicKeyJwk,
+        purpose: [PublicKeyPurpose.General, PublicKeyPurpose.KeyAgreement],
+      },
+    ],
+  };
+  const createOperation = await getCreatePayloadFromDocumentModel(
+    documentModel,
+    signingKeyPair.publicKeyJwk,
+    signingKeyPair.publicKeyJwk
+  );
+  expect(createOperation).toEqual(
+    walletSvipOperation.operation[0].createOperation
+  );
+});

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
@@ -11,7 +11,6 @@
  * limitations under the License.
  */
 import { Multihash, Encoder, OperationType } from '@sidetree/common';
-import jsonpatch from 'fast-json-patch';
 
 export const getCreatePayloadFromDocumentModel = async (
   documentModel: any,
@@ -20,8 +19,8 @@ export const getCreatePayloadFromDocumentModel = async (
 ): Promise<any> => {
   const patches = [
     {
-      action: 'ietf-json-patch',
-      patches: jsonpatch.compare({}, documentModel),
+      action: 'replace',
+      document: documentModel,
     },
   ];
 

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 - Transmute Industries Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Multihash, Encoder, OperationType } from '@sidetree/common';
+import jsonpatch from 'fast-json-patch';
+
+export const getCreatePayloadFromDocumentModel = async (
+  documentModel: any,
+  updatePublicKey: object,
+  recoveryPublicKey: object
+): Promise<any> => {
+  const patches = [
+    {
+      action: 'ietf-json-patch',
+      patches: jsonpatch.compare({}, documentModel),
+    },
+  ];
+  console.log(patches[0].patches);
+
+  const delta = {
+    update_commitment: Multihash.canonicalizeThenHashThenEncode(
+      updatePublicKey
+    ),
+    patches,
+  };
+
+  const deltaBuffer = Buffer.from(JSON.stringify(delta));
+  const deltaHash = Encoder.encode(Multihash.hash(deltaBuffer));
+  const suffixData = {
+    delta_hash: deltaHash,
+    recovery_commitment: Multihash.canonicalizeThenHashThenEncode(
+      recoveryPublicKey
+    ),
+  };
+
+  const suffixDataEncodedString = Encoder.encode(JSON.stringify(suffixData));
+  const deltaEncodedString = Encoder.encode(deltaBuffer);
+  const createOperationRequest = {
+    type: OperationType.Create,
+    suffix_data: suffixDataEncodedString,
+    delta: deltaEncodedString,
+  };
+  return createOperationRequest;
+};

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// import { Multihash, Encoder, OperationType } from '@sidetree/common';
 import canonicalize from 'canonicalize';
 import base64url from 'base64url';
 import { canonicalizeThenHashThenEncode } from './sidetreeEncoding';

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
@@ -27,15 +27,9 @@ export const getCreatePayloadFromDocumentModel = async (
       document: documentModel,
     },
   ];
-
   const delta_object = {
     update_commitment: canonicalizeThenHashThenEncode(updatePublicKey),
-    patches: [
-      {
-        action: 'replace',
-        document: documentModel,
-      },
-    ],
+    patches,
   };
   const delta = base64url.encode(canonicalize(delta_object));
   const canonical_suffix_data = canonicalize({

--- a/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
+++ b/packages/wallet/src/functions/getCreatePayloadFromDocumentModel.ts
@@ -24,7 +24,6 @@ export const getCreatePayloadFromDocumentModel = async (
       patches: jsonpatch.compare({}, documentModel),
     },
   ];
-  console.log(patches[0].patches);
 
   const delta = {
     update_commitment: Multihash.canonicalizeThenHashThenEncode(

--- a/packages/wallet/src/functions/index.ts
+++ b/packages/wallet/src/functions/index.ts
@@ -17,4 +17,5 @@ export * from './toKeyPair';
 // svip interop profile
 export * from './toDidDocForProfile';
 export * from './getCreateOperationForProfile';
+export * from './getCreatePayloadFromDocumentModel';
 export * from './getRecoverOperationForProfile';

--- a/packages/wallet/src/functions/sidetreeEncoding.ts
+++ b/packages/wallet/src/functions/sidetreeEncoding.ts
@@ -12,9 +12,9 @@
  */
 
 import crypto from 'crypto';
-import base64url from 'base64url';
-import multihashes from 'multihashes';
-import canonicalize from 'canonicalize';
+import { Multihash } from '@sidetree/common';
+
+const sha256AlgorithmMultihashCode = 18;
 
 export const sha256 = (data: Buffer): Buffer => {
   return crypto
@@ -24,11 +24,9 @@ export const sha256 = (data: Buffer): Buffer => {
 };
 
 export const hashThenEncode = (data: Buffer): string => {
-  const bytes = new Uint8Array(Buffer.from(sha256(data)));
-  return base64url.encode(multihashes.encode(bytes, 'sha2-256'));
+  return Multihash.hashThenEncode(data, sha256AlgorithmMultihashCode);
 };
 
 export const canonicalizeThenHashThenEncode = (data: object): string => {
-  const cannonical = canonicalize(data);
-  return hashThenEncode(cannonical);
+  return Multihash.canonicalizeThenHashThenEncode(data);
 };


### PR DESCRIPTION
## Batching

- Add a test in `did-method-photon` to show batching of size 1, 10, 100, 1000, 10000: Note that a batch size of 10000 causes the test to timeout, but it works when we increase jest.setTimeout 
- Add an efficient method for generating different create operation
- To make batching work for size > 100, changed `maxNumberOfOperationsForNoValueTimeLock` parameter from 100 to 10000

## Wallet

- Add a helper`getCreatePayloadFromDocumentModel` method, useful for generating did operations
- Add the corresponding test
- Use the `Multihash` class in sidetree encoding to avoid duplicating the encoding code.

## Cleanup

- Fix warning in console.info 
- Fix core tests
- Move ledger rest to utils
- Make `versionManager` a public attribute of the Did Method class

## To discuss

- Refactor parameters in Sidetree so that it's possible to change maxNumberOfOperationsForNoValueTimeLock easily -> ticket created
- What should max operation in a batch be? 1000 is safer than 10000 -> 1000 confirmed
- Encoding stuff in `packages/wallet` -> leave it as is because we want `wallet` to run in the browser
- Throttling test -> the operation queue should error if all operations cannot be included in next batch
