### PR TITLE
Version bump: 0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push]
+
+# Run on every push but not on tags
+on:
+  push:
+    tags-ignore:
+      - '**'
 jobs:
   ci:
     if: "! contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 # Run on every push but not on tags
 on:
   push:
-    tags-ignore:
+    branches:
       - '**'
+
 jobs:
   ci:
     if: "! contains(github.event.head_commit.message, 'skip ci')"

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.3-unstable.7"
+  "version": "0.2.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.3"
+  "version": "0.2.4-unstable.0"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "lerna run build --stream",
     "install:ci": "npm install --ignore-scripts && lerna link && lerna bootstrap --since origin/main --include-dependencies",
     "install:clean": "npx lerna clean -y && rm -rf node_modules && npm i",
-    "publish:stable:patch": "lerna publish patch",
+    "publish:stable:patch": "lerna publish patch --force-publish",
     "publish:stable:minor": "lerna publish minor",
     "publish:stable:major": "lerna publish major",
     "publish:unstable": "lerna publish prerelease --preid unstable --yes"

--- a/packages/cas-ipfs/package-lock.json
+++ b/packages/cas-ipfs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas-ipfs",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas-ipfs/package-lock.json
+++ b/packages/cas-ipfs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas-ipfs",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas-ipfs/package.json
+++ b/packages/cas-ipfs/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas-ipfs.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,9 +29,9 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3-unstable.7",
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/db": "^0.2.3-unstable.7",
+    "@sidetree/cas": "^0.2.3",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/db": "^0.2.3",
     "ipfs-http-client": "^49.0.2",
     "it-concat": "^1.0.0"
   },

--- a/packages/cas-ipfs/package.json
+++ b/packages/cas-ipfs/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas-ipfs.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,9 +29,9 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3",
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/db": "^0.2.3",
+    "@sidetree/cas": "^0.2.4-unstable.0",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/db": "^0.2.4-unstable.0",
     "ipfs-http-client": "^49.0.2",
     "it-concat": "^1.0.0"
   },

--- a/packages/cas-s3/package-lock.json
+++ b/packages/cas-s3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas-s3",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas-s3/package-lock.json
+++ b/packages/cas-s3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas-s3",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas-s3/package.json
+++ b/packages/cas-s3/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas-s3.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3-unstable.7",
-    "@sidetree/common": "^0.2.3-unstable.7",
+    "@sidetree/cas": "^0.2.3",
+    "@sidetree/common": "^0.2.3",
     "aws-sdk": "^2.823.0",
     "ipfs-unixfs": "^2.0.3",
     "ipld-dag-pb": "^0.20.0"

--- a/packages/cas-s3/package.json
+++ b/packages/cas-s3/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas-s3.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,8 +28,8 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3",
-    "@sidetree/common": "^0.2.3",
+    "@sidetree/cas": "^0.2.4-unstable.0",
+    "@sidetree/common": "^0.2.4-unstable.0",
     "aws-sdk": "^2.823.0",
     "ipfs-unixfs": "^2.0.3",
     "ipld-dag-pb": "^0.20.0"

--- a/packages/cas/package-lock.json
+++ b/packages/cas/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas/package-lock.json
+++ b/packages/cas/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas/package.json
+++ b/packages/cas/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,7 +28,7 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
+    "@sidetree/common": "^0.2.4-unstable.0",
     "ipfs-unixfs": "^2.0.3",
     "ipld-dag-pb": "^0.20.0"
   },

--- a/packages/cas/package.json
+++ b/packages/cas/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -28,7 +28,7 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
+    "@sidetree/common": "^0.2.3",
     "ipfs-unixfs": "^2.0.3",
     "ipld-dag-pb": "^0.20.0"
   },

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/common",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/common",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/common.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "engines": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/common.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "engines": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/core",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/core",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/core.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -30,18 +30,18 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3-unstable.7",
+    "@sidetree/test-vectors": "^0.2.3",
     "@types/async-retry": "^1.4.2",
     "@types/hdkey": "^0.7.1",
     "async-retry": "^1.3.1",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3-unstable.7",
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/crypto": "^0.2.3-unstable.7",
-    "@sidetree/db": "^0.2.3-unstable.7",
-    "@sidetree/ledger": "^0.2.3-unstable.7",
+    "@sidetree/cas": "^0.2.3",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/crypto": "^0.2.3",
+    "@sidetree/db": "^0.2.3",
+    "@sidetree/ledger": "^0.2.3",
     "@transmute/did-key-ed25519": "^0.2.1-unstable.18",
     "@transmute/did-key-secp256k1": "^0.2.1-unstable.11",
     "@trust/keyto": "^1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/core.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -30,18 +30,18 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0",
     "@types/async-retry": "^1.4.2",
     "@types/hdkey": "^0.7.1",
     "async-retry": "^1.3.1",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3",
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/crypto": "^0.2.3",
-    "@sidetree/db": "^0.2.3",
-    "@sidetree/ledger": "^0.2.3",
+    "@sidetree/cas": "^0.2.4-unstable.0",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/crypto": "^0.2.4-unstable.0",
+    "@sidetree/db": "^0.2.4-unstable.0",
+    "@sidetree/ledger": "^0.2.4-unstable.0",
     "@transmute/did-key-ed25519": "^0.2.1-unstable.18",
     "@transmute/did-key-secp256k1": "^0.2.1-unstable.11",
     "@trust/keyto": "^1.0.1",

--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/crypto",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/crypto/package-lock.json
+++ b/packages/crypto/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/crypto",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/crypto.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "engines": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/crypto.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "engines": {

--- a/packages/db/package-lock.json
+++ b/packages/db/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/db",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/db/package-lock.json
+++ b/packages/db/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/db",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/db.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,7 +33,7 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
+    "@sidetree/common": "^0.2.4-unstable.0",
     "@types/mongodb": "^3.5.20",
     "mongodb": "^3.5.8"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/db.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,7 +33,7 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
+    "@sidetree/common": "^0.2.3",
     "@types/mongodb": "^3.5.20",
     "mongodb": "^3.5.8"
   },

--- a/packages/did-method-element/package-lock.json
+++ b/packages/did-method-element/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/element",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-element/package-lock.json
+++ b/packages/did-method-element/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/element",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-element/package.json
+++ b/packages/did-method-element/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/element.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -30,18 +30,18 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3-unstable.7",
-    "@sidetree/wallet": "^0.2.3-unstable.7",
+    "@sidetree/test-vectors": "^0.2.3",
+    "@sidetree/wallet": "^0.2.3",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3-unstable.7",
-    "@sidetree/cas-ipfs": "^0.2.3-unstable.7",
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/core": "^0.2.3-unstable.7",
-    "@sidetree/db": "^0.2.3-unstable.7",
-    "@sidetree/did-method": "^0.2.3-unstable.7",
-    "@sidetree/ethereum": "^0.2.3-unstable.7",
+    "@sidetree/cas": "^0.2.3",
+    "@sidetree/cas-ipfs": "^0.2.3",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/core": "^0.2.3",
+    "@sidetree/db": "^0.2.3",
+    "@sidetree/did-method": "^0.2.3",
+    "@sidetree/ethereum": "^0.2.3",
     "web3": "^1.2.9"
   },
   "gitHead": "0c6ea3d3220464cf3975345eb6805b25bc823b0d",

--- a/packages/did-method-element/package.json
+++ b/packages/did-method-element/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/element.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -30,18 +30,18 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3",
-    "@sidetree/wallet": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0",
+    "@sidetree/wallet": "^0.2.4-unstable.0",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas": "^0.2.3",
-    "@sidetree/cas-ipfs": "^0.2.3",
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/core": "^0.2.3",
-    "@sidetree/db": "^0.2.3",
-    "@sidetree/did-method": "^0.2.3",
-    "@sidetree/ethereum": "^0.2.3",
+    "@sidetree/cas": "^0.2.4-unstable.0",
+    "@sidetree/cas-ipfs": "^0.2.4-unstable.0",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/core": "^0.2.4-unstable.0",
+    "@sidetree/db": "^0.2.4-unstable.0",
+    "@sidetree/did-method": "^0.2.4-unstable.0",
+    "@sidetree/ethereum": "^0.2.4-unstable.0",
     "web3": "^1.2.9"
   },
   "gitHead": "0c6ea3d3220464cf3975345eb6805b25bc823b0d",

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -26,17 +26,17 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/wallet": "^0.2.3",
+    "@sidetree/wallet": "^0.2.4-unstable.0",
     "aws-sdk": "^2.763.0",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas-s3": "^0.2.3",
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/db": "^0.2.3",
-    "@sidetree/did-method": "^0.2.3",
-    "@sidetree/qldb": "^0.2.3",
-    "@sidetree/test-vectors": "^0.2.3"
+    "@sidetree/cas-s3": "^0.2.4-unstable.0",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/db": "^0.2.4-unstable.0",
+    "@sidetree/did-method": "^0.2.4-unstable.0",
+    "@sidetree/qldb": "^0.2.4-unstable.0",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method-photon",
   "repository": {

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -26,17 +26,17 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/wallet": "^0.2.3-unstable.7",
+    "@sidetree/wallet": "^0.2.3",
     "aws-sdk": "^2.763.0",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas-s3": "^0.2.3-unstable.7",
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/db": "^0.2.3-unstable.7",
-    "@sidetree/did-method": "^0.2.3-unstable.7",
-    "@sidetree/qldb": "^0.2.3-unstable.7",
-    "@sidetree/test-vectors": "^0.2.3-unstable.7"
+    "@sidetree/cas-s3": "^0.2.3",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/db": "^0.2.3",
+    "@sidetree/did-method": "^0.2.3",
+    "@sidetree/qldb": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.3"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method-photon",
   "repository": {

--- a/packages/did-method/package-lock.json
+++ b/packages/did-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/did-method",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method/package-lock.json
+++ b/packages/did-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/did-method",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method/package.json
+++ b/packages/did-method/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/did-method.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,9 +32,9 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/core": "^0.2.3",
-    "@sidetree/db": "^0.2.3"
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/core": "^0.2.4-unstable.0",
+    "@sidetree/db": "^0.2.4-unstable.0"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method",
   "repository": {

--- a/packages/did-method/package.json
+++ b/packages/did-method/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/did-method.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,9 +32,9 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/core": "^0.2.3-unstable.7",
-    "@sidetree/db": "^0.2.3-unstable.7"
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/core": "^0.2.3",
+    "@sidetree/db": "^0.2.3"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method",
   "repository": {

--- a/packages/ledger-ethereum/package-lock.json
+++ b/packages/ledger-ethereum/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/ethereum",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger-ethereum/package-lock.json
+++ b/packages/ledger-ethereum/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/ethereum",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger-ethereum/package.json
+++ b/packages/ledger-ethereum/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/ethereum.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,15 +32,15 @@
     "web3": ">=1.2.7"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3-unstable.7",
+    "@sidetree/test-vectors": "^0.2.3",
     "@truffle/hdwallet-provider": "^1.0.35",
     "dotenv": "^8.2.0",
     "truffle": "^5.1.25",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/ledger": "^0.2.3-unstable.7",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/ledger": "^0.2.3",
     "multihashes": "^0.4.19",
     "web3": "1.3.0",
     "web3-eth-contract": "1.3.0"

--- a/packages/ledger-ethereum/package.json
+++ b/packages/ledger-ethereum/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/ethereum.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,15 +32,15 @@
     "web3": ">=1.2.7"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0",
     "@truffle/hdwallet-provider": "^1.0.35",
     "dotenv": "^8.2.0",
     "truffle": "^5.1.25",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/ledger": "^0.2.3",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/ledger": "^0.2.4-unstable.0",
     "multihashes": "^0.4.19",
     "web3": "1.3.0",
     "web3-eth-contract": "1.3.0"

--- a/packages/ledger-qldb/package-lock.json
+++ b/packages/ledger-qldb/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/qldb",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger-qldb/package-lock.json
+++ b/packages/ledger-qldb/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/qldb",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger-qldb/package.json
+++ b/packages/ledger-qldb/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/qldb.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,11 +25,11 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/ledger": "^0.2.3",
+    "@sidetree/ledger": "^0.2.4-unstable.0",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
+    "@sidetree/common": "^0.2.4-unstable.0",
     "amazon-qldb-driver-nodejs": "^2.1.0",
     "aws-sdk": "^2.828.0",
     "ion-js": "^4.1.0",

--- a/packages/ledger-qldb/package.json
+++ b/packages/ledger-qldb/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/qldb.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,11 +25,11 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/ledger": "^0.2.3-unstable.7",
+    "@sidetree/ledger": "^0.2.3",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
+    "@sidetree/common": "^0.2.3",
     "amazon-qldb-driver-nodejs": "^2.1.0",
     "aws-sdk": "^2.828.0",
     "ion-js": "^4.1.0",

--- a/packages/ledger/package-lock.json
+++ b/packages/ledger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/ledger",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger/package-lock.json
+++ b/packages/ledger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/ledger",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/ledger.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,11 +25,11 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3-unstable.7",
+    "@sidetree/test-vectors": "^0.2.3",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7"
+    "@sidetree/common": "^0.2.3"
   },
   "gitHead": "0c6ea3d3220464cf3975345eb6805b25bc823b0d",
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/ledger",

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/ledger.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,11 +25,11 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0",
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3"
+    "@sidetree/common": "^0.2.4-unstable.0"
   },
   "gitHead": "0c6ea3d3220464cf3975345eb6805b25bc823b0d",
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/ledger",

--- a/packages/test-vectors/package.json
+++ b/packages/test-vectors/package.json
@@ -8,7 +8,7 @@
     "Orie Steele (https://github.com/OR13)",
     "gjgd (https://github.com/gjgd)"
   ],
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "types": "typings.d.ts",

--- a/packages/test-vectors/package.json
+++ b/packages/test-vectors/package.json
@@ -8,7 +8,7 @@
     "Orie Steele (https://github.com/OR13)",
     "gjgd (https://github.com/gjgd)"
   ],
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "types": "typings.d.ts",

--- a/packages/wallet/package-lock.json
+++ b/packages/wallet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/wallet",
-	"version": "0.2.3-unstable.7",
+	"version": "0.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/wallet/package-lock.json
+++ b/packages/wallet/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/wallet",
-	"version": "0.2.3",
+	"version": "0.2.4-unstable.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -5,7 +5,7 @@
   },
   "author": "Orie Steele",
   "module": "dist/wallet.esm.js",
-  "version": "0.2.3-unstable.7",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3-unstable.7",
+    "@sidetree/test-vectors": "^0.2.3",
     "@transmute/universal-wallet": "^0.4.1",
     "@types/base64url": "^2.0.0",
     "tsdx": "^0.13.3"
@@ -34,8 +34,8 @@
     "@transmute/universal-wallet": "^0.4.1"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3-unstable.7",
-    "@sidetree/crypto": "^0.2.3-unstable.7",
+    "@sidetree/common": "^0.2.3",
+    "@sidetree/crypto": "^0.2.3",
     "base64url": "^3.0.1",
     "bip39": "^3.0.2",
     "canonicalize": "^1.0.3",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -5,7 +5,7 @@
   },
   "author": "Orie Steele",
   "module": "dist/wallet.esm.js",
-  "version": "0.2.3",
+  "version": "0.2.4-unstable.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "prepare": "tsdx build"
   },
   "devDependencies": {
-    "@sidetree/test-vectors": "^0.2.3",
+    "@sidetree/test-vectors": "^0.2.4-unstable.0",
     "@transmute/universal-wallet": "^0.4.1",
     "@types/base64url": "^2.0.0",
     "tsdx": "^0.13.3"
@@ -34,8 +34,8 @@
     "@transmute/universal-wallet": "^0.4.1"
   },
   "dependencies": {
-    "@sidetree/common": "^0.2.3",
-    "@sidetree/crypto": "^0.2.3",
+    "@sidetree/common": "^0.2.4-unstable.0",
+    "@sidetree/crypto": "^0.2.4-unstable.0",
     "base64url": "^3.0.1",
     "bip39": "^3.0.2",
     "canonicalize": "^1.0.3",


### PR DESCRIPTION
- Publish new stable version that fixes the did resolution context
- Run ci workflow on every push that is not tagged (otherwise two ci jobs will be launched for tagged commits)
- use `--force-publish` flag to publish an already published version
