### PR TITLE
Surface more information for block explorer

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.4-unstable.6"
+  "version": "0.2.4-unstable.7"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.4-unstable.4"
+  "version": "0.2.4-unstable.5"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.4-unstable.5"
+  "version": "0.2.4-unstable.6"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/test-vectors",
     "packages/wallet"
   ],
-  "version": "0.2.4-unstable.3"
+  "version": "0.2.4-unstable.4"
 }

--- a/packages/cas-s3/package-lock.json
+++ b/packages/cas-s3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/cas-s3",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cas-s3/package.json
+++ b/packages/cas-s3/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/cas-s3.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.7",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/cas-s3/src/S3Cas.spec.ts
+++ b/packages/cas-s3/src/S3Cas.spec.ts
@@ -19,6 +19,7 @@
 
 import { testSuite } from '@sidetree/cas';
 import S3Cas from './S3Cas';
+import casConfig from './cas-config.json';
 // import AWS object without services
 import AWS from 'aws-sdk/global';
 
@@ -31,6 +32,6 @@ if (!config.credentials) {
   describe = describe.skip;
 }
 
-const cas = new S3Cas('sidetree-cas-s3-test');
+const cas = new S3Cas(casConfig.s3BucketName);
 
 testSuite(cas);

--- a/packages/cas-s3/src/S3Cas.ts
+++ b/packages/cas-s3/src/S3Cas.ts
@@ -97,7 +97,7 @@ export default class S3Cas implements ICas {
     try {
       const readResult = await this.s3
         .getObject({
-          Bucket: 'sidetree-cas-s3-test',
+          Bucket: this.bucketName,
           Key: address,
         })
         .promise();

--- a/packages/cas-s3/src/cas-config.json
+++ b/packages/cas-s3/src/cas-config.json
@@ -1,0 +1,3 @@
+{
+  "s3BucketName": "sidetree-cas-s3-test"
+}

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/core",
-	"version": "0.2.4-unstable.4",
+	"version": "0.2.4-unstable.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/core",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/core.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/core.esm.js",
-  "version": "0.2.4-unstable.4",
+  "version": "0.2.4-unstable.5",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ import Compressor from './util/Compressor';
 import CreateOperation from './CreateOperation';
 import DeactivateOperation from './DeactivateOperation';
 import DownloadManager from './DownloadManager';
+import JsonAsync from './util/JsonAsync';
 import Jwk from './util/Jwk';
 import Jws from './util/Jws';
 import MapFile from './write/MapFile';
@@ -44,6 +45,7 @@ export {
   CreateOperation,
   DeactivateOperation,
   DownloadManager,
+  JsonAsync,
   Jwk,
   Jws,
   MapFile,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@
 import AnchorFile from './write/AnchorFile';
 import BatchScheduler from './write/BatchScheduler';
 import ChunkFile from './write/ChunkFile';
+import Compressor from './util/Compressor';
 import CreateOperation from './CreateOperation';
 import DeactivateOperation from './DeactivateOperation';
 import DownloadManager from './DownloadManager';
@@ -39,6 +40,7 @@ export {
   AnchorFile,
   BatchScheduler,
   ChunkFile,
+  Compressor,
   CreateOperation,
   DeactivateOperation,
   DownloadManager,

--- a/packages/did-method-element/package-lock.json
+++ b/packages/did-method-element/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/element",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-element/package-lock.json
+++ b/packages/did-method-element/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/element",
-	"version": "0.2.4-unstable.5",
+	"version": "0.2.4-unstable.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-element/package-lock.json
+++ b/packages/did-method-element/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/element",
-	"version": "0.2.4-unstable.4",
+	"version": "0.2.4-unstable.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-element/package.json
+++ b/packages/did-method-element/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/element.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,9 +38,9 @@
     "@sidetree/cas": "^0.2.4-unstable.3",
     "@sidetree/cas-ipfs": "^0.2.4-unstable.3",
     "@sidetree/common": "^0.2.4-unstable.3",
-    "@sidetree/core": "^0.2.4-unstable.3",
+    "@sidetree/core": "^0.2.4-unstable.4",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.3",
+    "@sidetree/did-method": "^0.2.4-unstable.4",
     "@sidetree/ethereum": "^0.2.4-unstable.3",
     "web3": "^1.2.9"
   },

--- a/packages/did-method-element/package.json
+++ b/packages/did-method-element/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/element.esm.js",
-  "version": "0.2.4-unstable.5",
+  "version": "0.2.4-unstable.6",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "@sidetree/common": "^0.2.4-unstable.3",
     "@sidetree/core": "^0.2.4-unstable.5",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.5",
+    "@sidetree/did-method": "^0.2.4-unstable.6",
     "@sidetree/ethereum": "^0.2.4-unstable.3",
     "web3": "^1.2.9"
   },

--- a/packages/did-method-element/package.json
+++ b/packages/did-method-element/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/element.esm.js",
-  "version": "0.2.4-unstable.4",
+  "version": "0.2.4-unstable.5",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,9 +38,9 @@
     "@sidetree/cas": "^0.2.4-unstable.3",
     "@sidetree/cas-ipfs": "^0.2.4-unstable.3",
     "@sidetree/common": "^0.2.4-unstable.3",
-    "@sidetree/core": "^0.2.4-unstable.4",
+    "@sidetree/core": "^0.2.4-unstable.5",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.4",
+    "@sidetree/did-method": "^0.2.4-unstable.5",
     "@sidetree/ethereum": "^0.2.4-unstable.3",
     "web3": "^1.2.9"
   },

--- a/packages/did-method-element/src/Element.spec.ts
+++ b/packages/did-method-element/src/Element.spec.ts
@@ -52,7 +52,7 @@ describe('Element', () => {
     expect(versions).toHaveLength(3);
     expect(versions[0].name).toBe('core');
     expect(versions[1].name).toBe('ethereum');
-    expect(versions[2].name).toBe('ipfs-with-cache');
+    expect(versions[2].name).toBe('mock-cas');
     expect(versions[0].version).toBeDefined();
     expect(versions[1].version).toBeDefined();
     expect(versions[2].version).toBeDefined();

--- a/packages/did-method-element/src/test/utils.ts
+++ b/packages/did-method-element/src/test/utils.ts
@@ -46,6 +46,7 @@ const getTestLedger = async () => {
 
 const getTestCas = async () => {
   // FIXME: IPFS has intermittent failures in tests so we will use MockCas until it's fixed
+  // See: https://github.com/transmute-industries/sidetree.js/runs/2178633982#step:8:178
   // const cas = new IpfsCasWithCache(
   //   config.contentAddressableStoreServiceUri,
   //   config.mongoDbConnectionString,

--- a/packages/did-method-element/src/test/utils.ts
+++ b/packages/did-method-element/src/test/utils.ts
@@ -18,7 +18,8 @@ import path from 'path';
 import { MongoDb } from '@sidetree/db';
 import Web3 from 'web3';
 import { EthereumLedger } from '@sidetree/ethereum';
-import { IpfsCasWithCache } from '@sidetree/cas-ipfs';
+// import { IpfsCasWithCache } from '@sidetree/cas-ipfs';
+import { MockCas } from '@sidetree/cas';
 import Element from '../Element';
 
 const config: any = require('./element-config.json');
@@ -44,11 +45,13 @@ const getTestLedger = async () => {
 };
 
 const getTestCas = async () => {
-  const cas = new IpfsCasWithCache(
-    config.contentAddressableStoreServiceUri,
-    config.mongoDbConnectionString,
-    config.databaseName
-  );
+  // FIXME: IPFS has intermittent failures in tests so we will use MockCas until it's fixed
+  // const cas = new IpfsCasWithCache(
+  //   config.contentAddressableStoreServiceUri,
+  //   config.mongoDbConnectionString,
+  //   config.databaseName
+  // );
+  const cas = new MockCas();
   return cas;
 };
 

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.4-unstable.6",
+	"version": "0.2.4-unstable.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.4-unstable.4",
+	"version": "0.2.4-unstable.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package-lock.json
+++ b/packages/did-method-photon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/photon",
-	"version": "0.2.4-unstable.5",
+	"version": "0.2.4-unstable.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.4-unstable.4",
+  "version": "0.2.4-unstable.5",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
     "@sidetree/cas-s3": "^0.2.4-unstable.3",
     "@sidetree/common": "^0.2.4-unstable.3",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.4",
+    "@sidetree/did-method": "^0.2.4-unstable.5",
     "@sidetree/qldb": "^0.2.4-unstable.3",
     "@sidetree/test-vectors": "^0.2.4-unstable.3"
   },

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
     "@sidetree/cas-s3": "^0.2.4-unstable.3",
     "@sidetree/common": "^0.2.4-unstable.3",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.3",
+    "@sidetree/did-method": "^0.2.4-unstable.4",
     "@sidetree/qldb": "^0.2.4-unstable.3",
     "@sidetree/test-vectors": "^0.2.4-unstable.3"
   },

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.4-unstable.5",
+  "version": "0.2.4-unstable.6",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,8 +34,8 @@
     "@sidetree/cas-s3": "^0.2.4-unstable.3",
     "@sidetree/common": "^0.2.4-unstable.3",
     "@sidetree/db": "^0.2.4-unstable.3",
-    "@sidetree/did-method": "^0.2.4-unstable.5",
-    "@sidetree/qldb": "^0.2.4-unstable.3",
+    "@sidetree/did-method": "^0.2.4-unstable.6",
+    "@sidetree/qldb": "^0.2.4-unstable.6",
     "@sidetree/test-vectors": "^0.2.4-unstable.3"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method-photon",

--- a/packages/did-method-photon/package.json
+++ b/packages/did-method-photon/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/photon.esm.js",
-  "version": "0.2.4-unstable.6",
+  "version": "0.2.4-unstable.7",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "tsdx": "^0.13.3"
   },
   "dependencies": {
-    "@sidetree/cas-s3": "^0.2.4-unstable.3",
+    "@sidetree/cas-s3": "^0.2.4-unstable.7",
     "@sidetree/common": "^0.2.4-unstable.3",
     "@sidetree/db": "^0.2.4-unstable.3",
     "@sidetree/did-method": "^0.2.4-unstable.6",

--- a/packages/did-method/package-lock.json
+++ b/packages/did-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/did-method",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method/package-lock.json
+++ b/packages/did-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/did-method",
-	"version": "0.2.4-unstable.4",
+	"version": "0.2.4-unstable.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method/package-lock.json
+++ b/packages/did-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/did-method",
-	"version": "0.2.4-unstable.5",
+	"version": "0.2.4-unstable.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/did-method/package.json
+++ b/packages/did-method/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/did-method.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@sidetree/common": "^0.2.4-unstable.3",
-    "@sidetree/core": "^0.2.4-unstable.3",
+    "@sidetree/core": "^0.2.4-unstable.4",
     "@sidetree/db": "^0.2.4-unstable.3"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method",

--- a/packages/did-method/package.json
+++ b/packages/did-method/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/did-method.esm.js",
-  "version": "0.2.4-unstable.4",
+  "version": "0.2.4-unstable.5",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@sidetree/common": "^0.2.4-unstable.3",
-    "@sidetree/core": "^0.2.4-unstable.4",
+    "@sidetree/core": "^0.2.4-unstable.5",
     "@sidetree/db": "^0.2.4-unstable.3"
   },
   "homepage": "https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method",

--- a/packages/did-method/package.json
+++ b/packages/did-method/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/did-method.esm.js",
-  "version": "0.2.4-unstable.5",
+  "version": "0.2.4-unstable.6",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/did-method/src/DidMethod.ts
+++ b/packages/did-method/src/DidMethod.ts
@@ -103,7 +103,8 @@ export default class DidMethod {
    */
   public async initialize(
     startObserver = true,
-    startBatchWriter = true
+    startBatchWriter = true,
+    startPeriodicCachedBlockchainTimeRefresh = false
   ): Promise<void> {
     await this.transactionStore.initialize();
     await this.unresolvableTransactionStore.initialize();
@@ -126,7 +127,9 @@ export default class DidMethod {
     if (startBatchWriter) {
       this.batchScheduler.startPeriodicBatchWriting();
     }
-    this.startPeriodicCachedBlockchainTimeRefresh();
+    if (startPeriodicCachedBlockchainTimeRefresh) {
+      this.startPeriodicCachedBlockchainTimeRefresh();
+    }
     this.downloadManager.start();
   }
 

--- a/packages/ledger-qldb/package-lock.json
+++ b/packages/ledger-qldb/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sidetree/qldb",
-	"version": "0.2.4-unstable.3",
+	"version": "0.2.4-unstable.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ledger-qldb/package.json
+++ b/packages/ledger-qldb/package.json
@@ -9,7 +9,7 @@
     "gjgd (https://github.com/gjgd)"
   ],
   "module": "dist/qldb.esm.js",
-  "version": "0.2.4-unstable.3",
+  "version": "0.2.4-unstable.6",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -107,10 +107,12 @@ export default class QLDBLedger implements IBlockchain {
 
   public async write(anchorString: string): Promise<void> {
     const anchorData = AnchoredDataSerializer.deserialize(anchorString);
-    await this.executeWithRetry(
-      `INSERT INTO ${this.transactionTable} ?`,
-      anchorData
-    );
+    const now = new Date();
+    await this.executeWithRetry(`INSERT INTO ${this.transactionTable} ?`, {
+      ...anchorData,
+      created: now.getTime(),
+      createdHumanReadable: now.toISOString(),
+    });
   }
 
   private toSidetreeTransaction(


### PR DESCRIPTION
- Expose `Compressor` and `JsonAsync` class from the `@sidetree/core` package
- Add timestamps to Sidetree transactions
- Disable periodic time refresh by default to increase Photon performance
- use MockCas in Element tests because of ipfs intermittent failures: https://github.com/transmute-industries/sidetree.js/runs/2178633982#step:8:178
- Fix bug in s3-cas: had an hardcoded bucket name