### PR TITLE
Fix/UI config

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -4,16 +4,6 @@ This package is work in progress.
 
 This package contains a Next.js app for sidetree nodes.
 
-### Add a Custom Logo to the Dashboard
-
-Create a file named `.evt.local` in this directory (next to `package.json`),
-and populate it with your logo URL's (without square brackets).
-
-```
-NEXT_PUBLIC_LOGO_LIGHT=[Light Logo on Dark Background URL]
-NEXT_PUBLIC_LOGO_DARK=[Dark Logo on Light Background URL]
-```
-
 ### Building with Docker
 
 This command does not work yet, need to address package manager differences (yarn vs npm)

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -7,13 +7,11 @@ This package contains a Next.js app for sidetree nodes.
 ### Add a Custom Logo to the Dashboard
 
 Create a file named `.evt.local` in this directory (next to `package.json`),
-and populate it with your logo URL's. `LOGO_LIGHT` is the light colored logo
-ontop of the dark background, and `LOGO_DARK` is the dark colored logo on top
-of a light background.
+and populate it with your logo URL's (without square brackets).
 
 ```
-LOGO_LIGHT=https://i.imgur.com/5OnYS9O.png
-LOGO_DARK=https://i.imgur.com/28872lr.png
+LOGO_LIGHT=[Light Logo on Dark Background URL]
+LOGO_DARK=[Dark Logo on Light Background URL]
 ```
 
 ### Building with Docker

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -10,8 +10,8 @@ Create a file named `.evt.local` in this directory (next to `package.json`),
 and populate it with your logo URL's (without square brackets).
 
 ```
-LOGO_LIGHT=[Light Logo on Dark Background URL]
-LOGO_DARK=[Dark Logo on Light Background URL]
+NEXT_PUBLIC_LOGO_LIGHT=[Light Logo on Dark Background URL]
+NEXT_PUBLIC_LOGO_DARK=[Dark Logo on Light Background URL]
 ```
 
 ### Building with Docker

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -4,6 +4,18 @@ This package is work in progress.
 
 This package contains a Next.js app for sidetree nodes.
 
+### Add a Custom Logo to the Dashboard
+
+Create a file named `.evt.local` in this directory (next to `package.json`),
+and populate it with your logo URL's. `LOGO_LIGHT` is the light colored logo
+ontop of the dark background, and `LOGO_DARK` is the dark colored logo on top
+of a light background.
+
+```
+LOGO_LIGHT=https://i.imgur.com/5OnYS9O.png
+LOGO_DARK=https://i.imgur.com/28872lr.png
+```
+
 ### Building with Docker
 
 This command does not work yet, need to address package manager differences (yarn vs npm)

--- a/packages/dashboard/components/company-logo.tsx
+++ b/packages/dashboard/components/company-logo.tsx
@@ -10,8 +10,8 @@ export const CompanyLogo = ({ sx }: any) => {
 
   const logo =
     theme.palette.mode === 'dark'
-      ? process.env.LOGO_LIGHT || '/assets/logo-with-text.white.svg'
-      : process.env.LOGO_DARK || '/assets/logo-with-text.purple.svg';
+      ? process.env.NEXT_PUBLIC_LOGO_LIGHT || '/assets/logo-with-text.white.svg'
+      : process.env.NEXT_PUBLIC_LOGO_DARK || '/assets/logo-with-text.purple.svg';
 
   return (
     <img

--- a/packages/dashboard/components/company-logo.tsx
+++ b/packages/dashboard/components/company-logo.tsx
@@ -11,7 +11,8 @@ export const CompanyLogo = ({ sx }: any) => {
   const logo =
     theme.palette.mode === 'dark'
       ? process.env.NEXT_PUBLIC_LOGO_LIGHT || '/assets/logo-with-text.white.svg'
-      : process.env.NEXT_PUBLIC_LOGO_DARK || '/assets/logo-with-text.purple.svg';
+      : process.env.NEXT_PUBLIC_LOGO_DARK ||
+        '/assets/logo-with-text.purple.svg';
 
   return (
     <img

--- a/packages/dashboard/components/company-logo.tsx
+++ b/packages/dashboard/components/company-logo.tsx
@@ -7,10 +7,11 @@ import { useRouter } from 'next/router';
 export const CompanyLogo = ({ sx }: any) => {
   const theme = useTheme();
   const router = useRouter();
+
   const logo =
     theme.palette.mode === 'dark'
-      ? '/assets/logo-with-text.white.svg'
-      : '/assets/logo-with-text.purple.svg';
+      ? process.env.LOGO_LIGHT || '/assets/logo-with-text.white.svg'
+      : process.env.LOGO_DARK || '/assets/logo-with-text.purple.svg';
 
   return (
     <img

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -2,6 +2,15 @@
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/wallet',
+        permanent: false,
+      },
+    ];
+  },
   reactStrictMode: true,
   webpack5: false,
   // Use the prefix in production and not development.


### PR DESCRIPTION
1. Set redirect from `/` to `wallet` to focus on usable UI. 
2. Added optional `.env.local` configuration to set custom branding. 

Example `.env.local`
```
NEXT_PUBLIC_LOGO_LIGHT=https://i.imgur.com/5OnYS9O.png
NEXT_PUBLIC_LOGO_DARK=https://i.imgur.com/28872lr.png
```

![Screenshot_2021-12-07 Element Wallet](https://user-images.githubusercontent.com/86194145/144903409-53053ebf-2bd8-4d21-9426-8e64de7f6a88.png)

