### PR TITLE
chore(element): add config for logo

### DIFF
--- a/packages/dashboard/.env.example
+++ b/packages/dashboard/.env.example
@@ -1,4 +1,6 @@
 # Client Side Variables -- Anything using NEXT_PUBLIC_ will be readable in the client
+NEXT_PUBLIC_LOGO_TEXT_DARK="/assets/logo-with-text.purple.svg"
+NEXT_PUBLIC_LOGO_TEXT_LIGHT="/assets/logo-with-text.white.svg"
 NEXT_PUBLIC_SIDETREE_METHOD="example:sidetree.testnet" # Can also be 'elem:ganache'
 NEXT_PUBLIC_ELEMENT_METHOD='elem:ganache'
 NEXT_PUBLIC_OPERATOR="Example Corp."

--- a/packages/dashboard/components/company-logo.tsx
+++ b/packages/dashboard/components/company-logo.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable @next/next/no-img-element */
 import * as React from 'react';
 import { useTheme } from '@mui/material/styles';
-
+import { nextAppConfigs } from '../config';
 import { useRouter } from 'next/router';
 
 export const CompanyLogo = ({ sx }: any) => {
   const theme = useTheme();
   const router = useRouter();
+
   const logo =
     theme.palette.mode === 'dark'
-      ? '/assets/logo-with-text.white.svg'
-      : '/assets/logo-with-text.purple.svg';
+      ? nextAppConfigs.logoLight
+      : nextAppConfigs.logoDark;
 
   return (
     <img

--- a/packages/dashboard/config/index.ts
+++ b/packages/dashboard/config/index.ts
@@ -1,6 +1,8 @@
 // todo: make this a single config for the entire node dashboard
 // including branding options, logos, etc.
 export const config: any = {
+  logoLight: process.env.NEXT_PUBLIC_LOGO_TEXT_LIGHT,
+  logoDark: process.env.NEXT_PUBLIC_LOGO_TEXT_DARK,
   operator: process.env.NEXT_PUBLIC_OPERATOR,
   method:
     process.env.NEXT_PUBLIC_USE_ELEMENT !== 'true'
@@ -20,6 +22,8 @@ export const config: any = {
 };
 
 export const nextAppConfigs = {
+  logoLight: config.logoLight,
+  logoDark: config.logoDark,
   operator: config.operator,
   method: config.method,
   description: config.description,


### PR DESCRIPTION
Added `NEXT_PUBLIC_LOGO_TEXT_DARK` and `NEXT_PUBLIC_LOGO_TEXT_LIGHT` to `.env.example`. Exposed the values via config, and added that to the CompanyLogo component. 