### PR TITLE
Adding Action to Publish Image to Docker Hub on Release Tagging

### DIFF
--- a/.github/workflows/publish-to-docker-hub.yml
+++ b/.github/workflows/publish-to-docker-hub.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: transmute/sidetree-dashboard
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -28,7 +28,7 @@ You can do this with the following command:
 ```
 git clone git@github.com:transmute-industries/sidetree.js.git
 cd sidetree.js
-lerna bootstrap
+npm install
 ```
 
 Important: The `lerna bootstrap` command will build all of the packages and link them so everything works properly.
@@ -46,6 +46,7 @@ So before doing anything you will need to copy the contents of `.env.example` to
 Now that we have confirmed we have all of the environment variables we need, we can install our dependencies with the following command (If you ran this after cloning the repo, you shouldn't need to run it again):
 
 ```
+cd packages/dashboard
 lerna bootstrap
 ```
 


### PR DESCRIPTION
This PR adds a GitHub action that should publish the docker image to DockerHub anytime a new release is tagged and published.

The link to the repository on DockerHub can be found here: https://hub.docker.com/r/transmute/sidetree-dashboard/tags

I have already published the Dockerfile currently in the repo. I have also already set up the repository secrets for `DOCKER_USERNAME` and `DOCKER_PASSWORD`.

