### PR TITLE
chore(core): gcp documentation

### DIFF
--- a/.github/workflows/cd-dashboard.yml
+++ b/.github/workflows/cd-dashboard.yml
@@ -43,7 +43,7 @@ jobs:
         run: gcloud auth configure-docker
 
       - name: Build and Push Container
-        working-directory: dashboard
+        working-directory: ./packages/dashboard
         run: |
           gcloud builds submit \
             --quiet \

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -129,6 +129,30 @@ Once resolved, we will be able to see basic information about the DID broken dow
 
 ### Instructions for deploying on GCP
 
-WIP
-
-See https://github.com/vercel/next.js/blob/canary/examples/with-docker/README.md
+1. `cd packages/dashboard`
+2. `cp .env.example .env`
+3. Set the variables in .env according to how you want your hosted sidetree setup.
+4. `docker-compose build`
+5. `docker-compose up`
+6.  At this point you should be able to test sidetree locally, to go to http://localhost:8080 in your browser.
+7. gcp cloud console setup https://github.com/transmute-industries/wikis/blob/master/docs/setup-gcp-continous-deployment.md
+8. Install gcp cloud sdk command line tools, configure it with the project and authenticate with the service account.
+9. Build and push the docker container to gcp.
+```
+gcloud builds submit \
+            --quiet \
+            --tag "gcr.io/$PROJECT_ID/$SERVICE:$GITHUB_SHA" \
+            --timeout=1200s \
+            --machine-type=n1-highcpu-32
+```
+10. Deploy container to cloud run.
+```
+gcloud run deploy $SERVICE \
+            --region $REGION \
+            --image gcr.io/$PROJECT_ID/$SERVICE:$github.sha \
+            --platform "managed" \
+            --set-env-vars NEXT_PUBLIC_TITLE="$NEXT_PUBLIC_TITLE",NEXT_PUBLIC_METHOD="$NEXT_PUBLIC_METHOD }}",... \
+            --service-account "$GCP_RUNNER_SA" \
+            --quiet
+```
+11. The command should give the url to check against that cloud run is on, you will need to make the https public


### PR DESCRIPTION
Documentation on how to deploy a docker container of sidetree dashboard to GCP.