### PR TITLE
chore(core): allowing optional parameter coin type in hd path

### DIFF
--- a/packages/crypto/src/mnemonic/toKeyPair.ts
+++ b/packages/crypto/src/mnemonic/toKeyPair.ts
@@ -22,11 +22,12 @@ import { SIDETREE_BIP44_COIN_TYPE } from '../constants';
 export const toKeyPair = async (
   mnemonic: string,
   index: number,
-  type = 'Ed25519'
+  type = 'Ed25519',
+  coinType = SIDETREE_BIP44_COIN_TYPE
 ): Promise<any> => {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const root = hdkey.fromMasterSeed(seed);
-  const hdPath = `m/44'/${SIDETREE_BIP44_COIN_TYPE}'/0'/0/${index}`;
+  const hdPath = `m/44'/${coinType}'/0'/0/${index}`;
   const addrNode = root.derive(hdPath);
 
   let keypair: any;

--- a/packages/crypto/src/mnemonic/toKeyPair.ts
+++ b/packages/crypto/src/mnemonic/toKeyPair.ts
@@ -23,7 +23,7 @@ export const toKeyPair = async (
   mnemonic: string,
   index: number,
   type = 'Ed25519',
-  hdPath: string | undefined
+  hdPath?: string
 ): Promise<any> => {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const root = hdkey.fromMasterSeed(seed);

--- a/packages/crypto/src/mnemonic/toKeyPair.ts
+++ b/packages/crypto/src/mnemonic/toKeyPair.ts
@@ -23,12 +23,13 @@ export const toKeyPair = async (
   mnemonic: string,
   index: number,
   type = 'Ed25519',
-  coinType = SIDETREE_BIP44_COIN_TYPE
+  hdPath: string | undefined
 ): Promise<any> => {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const root = hdkey.fromMasterSeed(seed);
-  const hdPath = `m/44'/${coinType}'/0'/0/${index}`;
-  const addrNode = root.derive(hdPath);
+  const addrNode = root.derive(
+    hdPath ? hdPath : `m/44'/${SIDETREE_BIP44_COIN_TYPE}'/0'/0/${index}`
+  );
 
   let keypair: any;
 


### PR DESCRIPTION
Should be allowed to specify the coin type, otherwise we cannot generate the correct ethereum addresses from a given mnemonic.