### PR TITLE
chore(photon): dashboard remove expired access token

### DIFF
--- a/packages/dashboard/services/sidetree-node-client-api.ts
+++ b/packages/dashboard/services/sidetree-node-client-api.ts
@@ -49,6 +49,7 @@ const getHeaders = (): HeadersInit => {
 const handleApiResponse = async (response: Response): Promise<any> => {
   if (!response.ok) {
     if (response.status === 401) {
+      localStorage.removeItem('sidetree.access_token');
       window.location.href = '/wallet';
     } else {
       throw new Error('HTTP error ' + response.status);


### PR DESCRIPTION
 In order to prompt for the credentials to renew the access token