### PR TITLE
Updating Dashboard Wallet Factory to Allow HD Path Input

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
     image: mongo
     restart: always
     ports:
-     - '27017:27017'
+      - '27017:27017'

--- a/packages/crypto/src/__tests__/generate-key-fixture.test.ts
+++ b/packages/crypto/src/__tests__/generate-key-fixture.test.ts
@@ -26,9 +26,9 @@ it('can generate test fixture', async () => {
 
   for (let i = 0; i < mnemonic.mnemonic.length; i++) {
     const m0 = mnemonic.mnemonic[i];
-    const k0 = await toKeyPair(m0, 0, 'Ed25519');
-    const k1 = await toKeyPair(m0, 0, 'X25519');
-    const k2 = await toKeyPair(m0, 0, 'secp256k1');
+    const k0 = await toKeyPair(m0, 'Ed25519', "m/44'/1'/0'/0/0");
+    const k1 = await toKeyPair(m0, 'X25519', "m/44'/1'/0'/0/0");
+    const k2 = await toKeyPair(m0, 'secp256k1', "m/44'/1'/0'/0/0");
 
     expect(k0).toBeDefined();
     expect(k1).toBeDefined();

--- a/packages/crypto/src/mnemonic/toKeyPair.ts
+++ b/packages/crypto/src/mnemonic/toKeyPair.ts
@@ -16,24 +16,16 @@ import * as bip39 from 'bip39';
 import hdkey from 'hdkey';
 import { Ed25519KeyPair } from '@transmute/ed25519-key-pair';
 import { JsonWebKey } from '@transmute/json-web-signature';
-import { SIDETREE_BIP44_COIN_TYPE } from '../constants';
 
 // See https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
 export const toKeyPair = async (
   mnemonic: string,
   type = 'Ed25519',
-  hdPath: string,
-  index = -1
+  hdPath: string
 ): Promise<any> => {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const root = hdkey.fromMasterSeed(seed);
-  const addrNode = root.derive(
-    hdPath
-      ? index >= 0
-        ? `${hdPath.slice(0, -1)}${index}`
-        : hdPath
-      : `m/44'/${SIDETREE_BIP44_COIN_TYPE}'/0'/0/${index >= 0 ? index : 0}`
-  );
+  const addrNode = root.derive(hdPath);
 
   let keypair: any;
 

--- a/packages/crypto/src/mnemonic/toKeyPair.ts
+++ b/packages/crypto/src/mnemonic/toKeyPair.ts
@@ -21,14 +21,18 @@ import { SIDETREE_BIP44_COIN_TYPE } from '../constants';
 // See https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
 export const toKeyPair = async (
   mnemonic: string,
-  index: number,
   type = 'Ed25519',
-  hdPath?: string
+  hdPath: string,
+  index = -1
 ): Promise<any> => {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const root = hdkey.fromMasterSeed(seed);
   const addrNode = root.derive(
-    hdPath ? hdPath : `m/44'/${SIDETREE_BIP44_COIN_TYPE}'/0'/0/${index}`
+    hdPath
+      ? index >= 0
+        ? `${hdPath.slice(0, -1)}${index}`
+        : hdPath
+      : `m/44'/${SIDETREE_BIP44_COIN_TYPE}'/0'/0/${index >= 0 ? index : 0}`
   );
 
   let keypair: any;

--- a/packages/dashboard/core/DashboardWallet.test.ts
+++ b/packages/dashboard/core/DashboardWallet.test.ts
@@ -1,4 +1,5 @@
 import { dashboardWalletFactory } from './DashboardWallet';
+import * as Sidetree from '@sidetree/wallet';
 
 describe('Dashboard Wallet', () => {
   it('creates wallet and operation create did', async () => {
@@ -24,5 +25,56 @@ describe('Dashboard Wallet', () => {
     const input1 = { recoveryKey, updateKey, document };
     const op0 = await wallet.operations.create(input1);
     expect(op0).toBeTruthy();
+  });
+
+  // API DID ACTOR KEY CREATION SANITY CHECK
+  // This test confirms the dashboardWalletFactory.toKeyPair() and @sidetree/wallet's toKeyPair()
+  // generate the exact same keys as API did actor when using the same parameters.
+  it('ensure same did:key gets created here as in api.did.actor using same params', async () => {
+    const mnemonic =
+      'walnut zoo hamster tumble just smooth post myth task thought finger illegal';
+    const wallet: any = dashboardWalletFactory.build();
+    const content = await wallet.toKeyPair(
+      mnemonic,
+      0,
+      'secp256k1',
+      "m/44'/0'/0'/0/0"
+    );
+    const content2 = await Sidetree.toKeyPair(
+      mnemonic,
+      0,
+      'secp256k1',
+      "m/44'/0'/0'/0/0"
+    );
+    expect(content2?.controller).toEqual(content.controller);
+    expect(content2?.controller).toEqual(
+      'did:key:zQ3shjEgDKdK5bBU6Y9GhtZndZ7YTh4KkE2Ff22Xv36RGbKJC'
+    );
+  });
+
+  // This test ensures that the same wallet.toKeyPair() function running on https://photon.transmute.industries/create
+  // inside the create.ts file generates the same key0 when using the same inputs
+  // Currently busted as it seems https://photon.transmute.industries/create generates the same key
+  // regardless of inputs
+  it('ensure same did:key gets created here as in @wallet package using exact same inputs', async () => {
+    const mnemonic =
+      'life state degree blade flower festival absurd anger rifle property upon time';
+    const wallet: any = dashboardWalletFactory.build();
+    const content = await wallet.toKeyPair(
+      mnemonic,
+      0,
+      'secp256k1',
+      "m/44'/1'/0'/0/0"
+    );
+    const content2 = await Sidetree.toKeyPair(
+      mnemonic,
+      0,
+      'secp256k1',
+      "m/44'/1'/0'/0/0"
+    );
+    expect(content2?.controller).toEqual(content.controller);
+    expect(content.controller).toEqual(
+      'did:key:zQ3shvfXLUVwKffPochZ1UkSjxQqpgND3Z5DhzTADooqmmypp'
+    );
   });
 });

--- a/packages/dashboard/core/DashboardWallet.test.ts
+++ b/packages/dashboard/core/DashboardWallet.test.ts
@@ -56,7 +56,8 @@ describe('Dashboard Wallet', () => {
   // inside the create.ts file generates the same key0 when using the same inputs
   // Currently busted as it seems https://photon.transmute.industries/create generates the same key
   // regardless of inputs
-  it('ensure same did:key gets created here as in @wallet package using exact same inputs', async () => {
+  // THIS TEST CURRENTLY FAILS
+  xit('ensure same did:key gets created here as in @wallet package using exact same inputs', async () => {
     const mnemonic =
       'life state degree blade flower festival absurd anger rifle property upon time';
     const wallet: any = dashboardWalletFactory.build();

--- a/packages/dashboard/core/DashboardWallet.test.ts
+++ b/packages/dashboard/core/DashboardWallet.test.ts
@@ -7,9 +7,21 @@ describe('Dashboard Wallet', () => {
     const mnemonic = await wallet.toMnemonic();
     wallet.add(mnemonic);
     const keyType = 'secp256k1';
-    const key0 = await wallet.toKeyPair(mnemonic.value, 0, keyType);
-    const key1 = await wallet.toKeyPair(mnemonic.value, 1, keyType);
-    const key2 = await wallet.toKeyPair(mnemonic.value, 2, keyType);
+    const key0 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/0'/0'/0/0"
+    );
+    const key1 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/0'/0'/0/1"
+    );
+    const key2 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/0'/0'/0/2"
+    );
     const document: any = {
       publicKeys: [
         {
@@ -36,13 +48,11 @@ describe('Dashboard Wallet', () => {
     const wallet: any = dashboardWalletFactory.build();
     const content = await wallet.toKeyPair(
       mnemonic,
-      0,
       'secp256k1',
       "m/44'/0'/0'/0/0"
     );
     const content2 = await Sidetree.toKeyPair(
       mnemonic,
-      0,
       'secp256k1',
       "m/44'/0'/0'/0/0"
     );

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -15,7 +15,8 @@
     "@babel/compat-data": {
       "version": "7.16.4",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q=="
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.16.0",
@@ -70,6 +71,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
       "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
@@ -80,6 +82,7 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
       "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -91,6 +94,7 @@
           "version": "4.18.1",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
           "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
+          "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30001280",
             "electron-to-chromium": "^1.3.896",
@@ -102,37 +106,8 @@
         "node-releases": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-          "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
-        }
-      }
-    },
-    "@babel/helper-define-polyfill-provider": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
-      "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
-      "requires": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+          "dev": true
         }
       }
     },
@@ -140,6 +115,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
       "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.16.0",
         "@babel/template": "^7.16.0",
@@ -150,6 +126,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
       "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -158,6 +135,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
       "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -234,6 +212,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
       "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -246,7 +225,8 @@
     "@babel/helper-validator-option": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true
     },
     "@babel/helpers": {
       "version": "7.16.3",
@@ -272,7 +252,8 @@
     "@babel/parser": {
       "version": "7.16.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -399,48 +380,6 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
-      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "babel-plugin-polyfill-corejs2": "^0.3.0",
-        "babel-plugin-polyfill-corejs3": "^0.5.0",
-        "babel-plugin-polyfill-regenerator": "^0.3.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-          "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-          "requires": {
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
-        },
-        "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.16.7",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
     "@babel/runtime": {
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
@@ -463,6 +402,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
       "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/parser": "^7.16.0",
@@ -473,6 +413,7 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
       "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/generator": "^7.16.0",
@@ -489,6 +430,7 @@
           "version": "4.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
           "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -496,12 +438,14 @@
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -519,38 +463,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@bitauth/libauth": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@bitauth/libauth/-/libauth-1.19.1.tgz",
-      "integrity": "sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug=="
-    },
-    "@did-core/data-model": {
-      "version": "0.1.1-unstable.15",
-      "resolved": "https://registry.npmjs.org/@did-core/data-model/-/data-model-0.1.1-unstable.15.tgz",
-      "integrity": "sha512-l7gxLxegcXW7389G+j6o+S24lS8uasmJx5txWpW3QadNvOawKwvWn8bV59SdHSK806xNzIZaCLKmXKxebs8yAQ==",
-      "requires": {
-        "factory.ts": "^0.5.1"
-      }
-    },
-    "@did-core/did-ld-json": {
-      "version": "0.1.1-unstable.15",
-      "resolved": "https://registry.npmjs.org/@did-core/did-ld-json/-/did-ld-json-0.1.1-unstable.15.tgz",
-      "integrity": "sha512-p2jKRxSU+eJJqd+ewCklYp/XZ6ysISk8VU2/kANCoB/WwUy/kVgw2rUNScRDXw2utr9Qj36P8EZTYi4aj7vRCQ==",
-      "requires": {
-        "@transmute/did-context": "^0.6.1-unstable.25",
-        "jsonld-checker": "^0.1.6"
-      }
-    },
-    "@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "requires": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
-      }
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",
@@ -918,65 +830,6 @@
         "@ethersproject/strings": "^5.5.0"
       }
     },
-    "@gjgd/ion-sdk": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@gjgd/ion-sdk/-/ion-sdk-0.5.2.tgz",
-      "integrity": "sha512-2JuCgqEum6ovTtnksHI3SG74Y1kiHztndzwQGmZzYv/RH3eHkk90G0QKGpc6GWV+iZ1NiN/dRZ3T+sEau+Q0yw==",
-      "requires": {
-        "@transmute/ed25519-key-pair": "0.7.0-unstable.28",
-        "@transmute/jose-ld": "0.7.0-unstable.28",
-        "@transmute/secp256k1-key-pair": "0.7.0-unstable.28",
-        "@waiting/base64": "4.2.9",
-        "canonicalize": "1.0.1",
-        "multihashes": "0.4.14",
-        "randombytes": "2.1.0",
-        "uri-js": "4.4.0"
-      },
-      "dependencies": {
-        "@transmute/ed25519-key-pair": {
-          "version": "0.7.0-unstable.28",
-          "resolved": "https://registry.npmjs.org/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.7.0-unstable.28.tgz",
-          "integrity": "sha512-ad6gkOp0utGuspLPpg7yI59CH2CVbvDb9gdzWvvq19mV4zTme+5Agj/Mj6XXENHdW9jPK0QASkhdZDjLupTgfQ==",
-          "requires": {
-            "@stablelib/ed25519": "^1.0.1",
-            "@transmute/ld-key-pair": "^0.7.0-unstable.28",
-            "@transmute/x25519-key-pair": "^0.7.0-unstable.28"
-          }
-        },
-        "@transmute/secp256k1-key-pair": {
-          "version": "0.7.0-unstable.28",
-          "resolved": "https://registry.npmjs.org/@transmute/secp256k1-key-pair/-/secp256k1-key-pair-0.7.0-unstable.28.tgz",
-          "integrity": "sha512-B3it+JwUkSDWR6gSRSUPyujb5YUov9flSDQ45lGmDCvRTW/hv/8cv1aI3Rf6ATz/DFbi8sa9yei0JsaLUNxahA==",
-          "requires": {
-            "@bitauth/libauth": "^1.18.1",
-            "@transmute/ld-key-pair": "^0.7.0-unstable.28",
-            "secp256k1": "^4.0.2"
-          }
-        },
-        "canonicalize": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.1.tgz",
-          "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg=="
-        },
-        "multihashes": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.14.tgz",
-          "integrity": "sha512-V/g/EIN6nALXfS/xHUAgtfPP3mn3sPIF/i9beuGKf25QXS2QZYCpeVJbDPEannkz32B2fihzCe2D/KMrbcmefg==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "uri-js": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        }
-      }
-    },
     "@hapi/accept": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
@@ -1216,6 +1069,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.2.tgz",
       "integrity": "sha512-uSljKxh/rGlHlmhyeG4ZoVK9hOec+EPBkwTHkHKQ2EqDu5K+MaG9uJZ8o1CbRsSdZqSuhXvJCYhBWsORPPg6qw==",
+      "dev": true,
       "requires": {
         "@jest/fake-timers": "^27.4.2",
         "@jest/types": "^27.4.2",
@@ -1227,6 +1081,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.2.tgz",
       "integrity": "sha512-f/Xpzn5YQk5adtqBgvw1V6bF8Nx3hY0OIRRpCvWcfPl0EAjdqWPdhH3t/3XpiWZqtjIEHDyMKP9ajpva1l4Zmg==",
+      "dev": true,
       "requires": {
         "@jest/types": "^27.4.2",
         "@sinonjs/fake-timers": "^8.0.1",
@@ -1486,6 +1341,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
       "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -1498,6 +1354,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -1506,6 +1363,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1515,6 +1373,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1522,55 +1381,25 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         }
       }
-    },
-    "@mattrglobal/bbs-signatures": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.5.0.tgz",
-      "integrity": "sha512-4te4TpacAmeCM8aa/kHkU0i1IJwsO1x/Tez6/YLUWg6rK6bfGA1NNO7IBc12u9ETkoTsiU32UmsiYWXcw9QwKQ==",
-      "requires": {
-        "@mattrglobal/node-bbs-signatures": "0.11.0"
-      }
-    },
-    "@mattrglobal/bls12381-key-pair": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.5.0.tgz",
-      "integrity": "sha512-eXAtke0HOEr9RcT+NEI1MERE50gUnnLm1mYBJkUugk9REP3MfKXtX2Mo4FXyCH/IR4Oxj2jCcfNYW/h0Q3x5sg==",
-      "requires": {
-        "@mattrglobal/bbs-signatures": "0.5.0",
-        "bs58": "4.0.1",
-        "rfc4648": "1.4.0"
-      }
-    },
-    "@mattrglobal/node-bbs-signatures": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz",
-      "integrity": "sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==",
-      "optional": true,
-      "requires": {
-        "neon-cli": "0.4.0",
-        "node-pre-gyp": "0.14.0"
-      }
-    },
-    "@metamask/safe-event-emitter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
-      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
     "@mui/base": {
       "version": "5.0.0-alpha.56",
@@ -1720,11 +1549,6 @@
         "prop-types": "^15.7.2",
         "reselect": "^4.1.1"
       }
-    },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "@napi-rs/triples": {
       "version": "1.1.0",
@@ -1967,446 +1791,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
       "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
     },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
-    },
-    "@rollup/plugin-replace": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-3.0.1.tgz",
-      "integrity": "sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==",
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "requires": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      }
-    },
     "@rushstack/eslint-patch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz",
       "integrity": "sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==",
       "dev": true
-    },
-    "@sidetree/cas": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/cas/-/cas-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-sd0Xg7jwlEN9AxX8as4sii5rf8ZJGFAgIrUN6vz45Ty/tTZkRdo/3/skLmbWdcqXZFDWz62TCi+T8PIxglo0HQ==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/test-vectors": "^0.3.1-unstable.39",
-        "ipfs-unixfs": "^2.0.3",
-        "ipld-dag-pb": "^0.20.0",
-        "jest-environment-node": "^27.2.5"
-      }
-    },
-    "@sidetree/cas-ipfs": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/cas-ipfs/-/cas-ipfs-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-t+I7hJy4vjdyd3lFwoJnV0xf8S1dNTFEJYgLwUPDSwKT/gBzPpyMHHxRyJJD5QtVh/3llUyuEGxAhi+9Lx+h+Q==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/db": "^0.3.1-unstable.39",
-        "ipfs-http-client": "^49.0.2",
-        "it-concat": "^1.0.0"
-      }
-    },
-    "@sidetree/cas-s3": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/cas-s3/-/cas-s3-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-IdCjb5zmO+Z6xmLpbsIKwR5vUNj/HoiqGTZZayhHQ3nQxFqSkkPfdDkJyklq1np/fgWpKmD1fiYtsBseJQ289g==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "aws-sdk": "^2.823.0",
-        "ipfs-unixfs": "^2.0.3",
-        "ipld-dag-pb": "^0.20.0"
-      }
-    },
-    "@sidetree/common": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/common/-/common-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-T/XZcuidXWkDeXaW92kvINFJB7Ra0bgaqol3BsBSxjCAb+xdOeQy5VQEn7Oq/cCW4TpS2KT0/l3xTeGXG4dHdg==",
-      "requires": {
-        "base64url": "^3.0.1",
-        "canonicalize": "^1.0.1",
-        "chalk": "^4.1.2",
-        "multiformats": "^9.4.8",
-        "multihashes": "^0.4.19"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@sidetree/core": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/core/-/core-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-iaQRId1CSLQF+lS3Iuam2d/hN1dde1sEUIxe9kT9rv2b75FtZUAjerOU+jj/JqdM7nxr35nz0fm5q/NOwuwoiw==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/crypto": "^0.3.1-unstable.39",
-        "@sidetree/db": "^0.3.1-unstable.39",
-        "@transmute/did-key-ed25519": "^0.3.0-unstable.4",
-        "@trust/keyto": "^1.0.1",
-        "bip39": "^3.0.2",
-        "canonicalize": "^1.0.5",
-        "chalk": "^4.1.0",
-        "core-js": "^2.6.9",
-        "hdkey": "^2.0.1",
-        "jose": "^4.5.0",
-        "priorityqueue": "^1.0.0",
-        "time-span": "3.1.0",
-        "uri-js": "^4.4.1",
-        "yieldable-json": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@sidetree/crypto": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/crypto/-/crypto-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-18r0ZyY8GM9btBpKNzZC296jlfSHAyk9UkqU1tslRsK+N8Uc4CX4usU8enbEoFEp3l0WThlUimXophpsQsc7vA==",
-      "requires": {
-        "@rollup/plugin-replace": "^3.0.0",
-        "@transmute/ed25519-key-pair": "^0.7.0-unstable.8",
-        "@transmute/json-web-signature": "^0.7.0-unstable.8",
-        "bip39": "^3.0.2",
-        "hdkey": "^2.0.1"
-      }
-    },
-    "@sidetree/db": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/db/-/db-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-EKNjgFm04eEfV38AWtJ1XK8zJ7xjstzd5YBWtj4u/tEO/KaV9xpvft/mb176cNaSGUwSIMCnRL+3p0hffHCrFw==",
-      "requires": {
-        "@rollup/plugin-replace": "^3.0.0",
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@types/mongodb": "^3.5.20",
-        "mongodb": "^3.6.9"
-      }
-    },
-    "@sidetree/did-method": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/did-method/-/did-method-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-trFJ7ilPN2xbof4rHN/5n1V2YIDyxsh72voCQfvrjXhJGxfA1OsRQrwfWmMkgi997fVpfMQkUgMgj+Dd+t/ZeQ==",
-      "requires": {
-        "@rollup/plugin-replace": "^3.0.0",
-        "@sidetree/cas": "^0.3.1-unstable.39",
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/core": "^0.3.1-unstable.39",
-        "@sidetree/db": "^0.3.1-unstable.39",
-        "@sidetree/ledger": "^0.3.1-unstable.39",
-        "mongodb": "^4.1.2",
-        "semver": "^7.3.5",
-        "time-span": "3.1.0"
-      },
-      "dependencies": {
-        "denque": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
-        },
-        "mongodb": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-          "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
-          "requires": {
-            "bson": "^4.6.1",
-            "denque": "^2.0.1",
-            "mongodb-connection-string-url": "^2.4.1",
-            "saslprep": "^1.0.3",
-            "socks": "^2.6.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@sidetree/element": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/element/-/element-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-gVAC/2Dt87HBeTZUpaDUNTLHMwn0cRBq4BTpo+JcgdHLVtoNDSlHgiIHvzf457eh6lLYiflw61OuPio9OodtJQ==",
-      "requires": {
-        "@rollup/plugin-replace": "^3.0.0",
-        "@sidetree/cas": "^0.3.1-unstable.39",
-        "@sidetree/cas-ipfs": "^0.3.1-unstable.39",
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/core": "^0.3.1-unstable.39",
-        "@sidetree/db": "^0.3.1-unstable.39",
-        "@sidetree/did-method": "^0.3.1-unstable.39",
-        "@sidetree/ethereum": "^0.3.1-unstable.39",
-        "@truffle/hdwallet-provider": "^2.0.0",
-        "jest-environment-node": "^27.2.5",
-        "mongodb": "^4.1.2",
-        "web3": "^1.2.9"
-      },
-      "dependencies": {
-        "denque": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
-        },
-        "mongodb": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-          "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
-          "requires": {
-            "bson": "^4.6.1",
-            "denque": "^2.0.1",
-            "mongodb-connection-string-url": "^2.4.1",
-            "saslprep": "^1.0.3",
-            "socks": "^2.6.1"
-          }
-        }
-      }
-    },
-    "@sidetree/ethereum": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/ethereum/-/ethereum-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-e/+twcSf/AABijYHEkMLLh8IbI5X1rnbD7rhQ7rEN69f4mYJRABDf2ULLj5jzaXcKDWRywsHvBmNs93TJAkkpw==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/core": "^0.3.1-unstable.39",
-        "web3": "^1.3.6",
-        "web3-eth": "^1.6.0",
-        "web3-eth-contract": "^1.3.6"
-      }
-    },
-    "@sidetree/ledger": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/ledger/-/ledger-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-EkZl/SMhF2/kJP73EUzRhZoyMD4dniCc3mzLSSSXweW4BOCcc3V7nR3BGLVgucrZwiwY45Ge8D3z9DZ/vmI1tg==",
-      "requires": {
-        "@rollup/plugin-replace": "^3.0.0",
-        "@sidetree/common": "^0.3.1-unstable.39"
-      }
-    },
-    "@sidetree/photon": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/photon/-/photon-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-YoF4PPT4GHuTgM1QSgkdQJ2NsYPXE149BHhqUeDLbdpTwYIiYf/vFthSmRxIjnvRZgm4sx+2NsJwi4NHp7ExVA==",
-      "requires": {
-        "@sidetree/cas": "^0.3.1-unstable.39",
-        "@sidetree/cas-s3": "^0.3.1-unstable.39",
-        "@sidetree/did-method": "^0.3.1-unstable.39",
-        "@sidetree/qldb": "^0.3.1-unstable.39"
-      }
-    },
-    "@sidetree/qldb": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/qldb/-/qldb-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-TBa330Hsebbi/QITY7t0sp055gJUgmaaoBU88YMsi25L+DsaJO6tsazDBEcDXX1vP+0N2ThNmZVBAO6H4mlklA==",
-      "requires": {
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/core": "^0.3.1-unstable.39",
-        "amazon-qldb-driver-nodejs": "^2.2.0",
-        "aws-sdk": "^2.828.0",
-        "ion-js": "^4.1.0",
-        "jsbi": "^3.1.4",
-        "moment": "^2.29.1",
-        "sqlite3": "^5.0.2"
-      }
-    },
-    "@sidetree/test-vectors": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/test-vectors/-/test-vectors-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-dc9h3mVodMPK0+EiNH9cf7i0b5yV9Ojjiz5cr07L/S59QlF/RbmyTuSOWx6IP4gMMF/pV9pHFnbGmwZlWKgzrQ=="
-    },
-    "@sidetree/wallet": {
-      "version": "0.3.1-unstable.39",
-      "resolved": "https://registry.npmjs.org/@sidetree/wallet/-/wallet-0.3.1-unstable.39.tgz",
-      "integrity": "sha512-+UjQxX9C+viVIcr2nFXif/5NhIh5mIz/gEhrNe3f+LsLPmL9g/rS2TeHfon/qVPmORC8rXK9P3jWVOZqYejwyw==",
-      "requires": {
-        "@gjgd/ion-sdk": "0.5.2",
-        "@rollup/plugin-replace": "^3.0.0",
-        "@sidetree/common": "^0.3.1-unstable.39",
-        "@sidetree/crypto": "^0.3.1-unstable.39",
-        "@transmute/universal-wallet": "^0.6.0",
-        "bip39": "^3.0.2",
-        "factory.ts": "^0.5.1",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "@transmute/universal-wallet": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@transmute/universal-wallet/-/universal-wallet-0.6.0.tgz",
-          "integrity": "sha512-zZWbW3J0J02aH7rXC4Szygzy2gTYzaujK2KnTYX/07uA0872N92auEmU+Z+Cv+cWk7CsTYULNAeQFlchue9pKA==",
-          "requires": {
-            "@peculiar/webcrypto": "^1.1.4",
-            "@transmute/did-key-cipher": "^0.2.1-unstable.31",
-            "@transmute/did-key-x25519": "^0.2.1-unstable.31",
-            "@transmute/universal-wallet-test-vectors": "^0.6.0",
-            "core-js": "^3.8.3",
-            "factory.ts": "^0.5.1"
-          }
-        },
-        "@transmute/universal-wallet-test-vectors": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@transmute/universal-wallet-test-vectors/-/universal-wallet-test-vectors-0.6.0.tgz",
-          "integrity": "sha512-9lMGMV7yQ0eJfM9M39un0e/xd2h0LxOlbORG58pFpU22GaYlpbGwt4GQAucjMJ3C7hesZRLcTwQWoHNl8hRR3A==",
-          "requires": {
-            "@transmute/jsonld-document-loader": "^0.2.0"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -2417,6 +1806,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
       "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -2425,6 +1815,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -2501,21 +1892,6 @@
       "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
       "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
     },
-    "@stablelib/ed25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.2.tgz",
-      "integrity": "sha512-FtnvUwvKbp6l1dNcg4CswMAVFVu/nzLK3oC7/PRtjYyHbWsIkD8j+5cjXHmwcCpdCpRCaTGACkEhhMQ1RcdSOQ==",
-      "requires": {
-        "@stablelib/random": "^1.0.1",
-        "@stablelib/sha512": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/hash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
-    },
     "@stablelib/int": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
@@ -2544,16 +1920,6 @@
       "integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
       "requires": {
         "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/sha512": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
-      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -2608,169 +1974,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@transmute/bls12381-key-pair": {
-      "version": "0.7.0-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/bls12381-key-pair/-/bls12381-key-pair-0.7.0-unstable.42.tgz",
-      "integrity": "sha512-j/OcPxQETIKEA/PzNwrJZhBj8tyiVjZC4MrMFAxs0ivBcycJH6nP/pl+1W6dkgsqibYhlqzHhURcVL2FLhg9qg==",
-      "requires": {
-        "@mattrglobal/bls12381-key-pair": "^0.5.0",
-        "@transmute/ld-key-pair": "^0.7.0-unstable.42"
-      },
-      "dependencies": {
-        "@transmute/ld-key-pair": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-nYo+KwOr/P8cXTbueBQjjaNASJkhzpbeu2sN7UBdT1kLDD5Ngrkb7pKD5jMSUudY8mIn+Chn9cTzQ/uEa3TDUw=="
-        }
-      }
-    },
     "@transmute/credentials-context": {
       "version": "0.7.0-unstable.28",
       "resolved": "https://registry.npmjs.org/@transmute/credentials-context/-/credentials-context-0.7.0-unstable.28.tgz",
       "integrity": "sha512-yW5TCBDNp1JzWiMZD3Av04EKVcf+zBTZ6pZe8Z+zILpsDineDYd4BBUP3Q7Z6/oyL8hcL/zyoH3Zoi1nuED6xA=="
-    },
-    "@transmute/did-context": {
-      "version": "0.6.1-unstable.37",
-      "resolved": "https://registry.npmjs.org/@transmute/did-context/-/did-context-0.6.1-unstable.37.tgz",
-      "integrity": "sha512-p/QnG3QKS4218hjIDgdvJOFATCXsAnZKgy4egqRrJLlo3Y6OaDBg7cA73dixOwUPoEKob0K6rLIGcsCI/L1acw=="
-    },
-    "@transmute/did-key-cipher": {
-      "version": "0.2.1-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.42.tgz",
-      "integrity": "sha512-drD/G7R2yQkK6PnGkmLOlOieL3ybtiEXsubaebaBayoRsWqBRX/IJ0ufGwjRgohTvvlSoKWd4Ustyyhi9kK+Mw==",
-      "requires": {
-        "@peculiar/webcrypto": "^1.1.3",
-        "@stablelib/aes-kw": "^1.0.0",
-        "@stablelib/xchacha20poly1305": "^1.0.0",
-        "@transmute/did-key-common": "^0.2.1-unstable.42",
-        "web-streams-polyfill": "^3.0.0"
-      },
-      "dependencies": {
-        "@transmute/did-key-common": {
-          "version": "0.2.1-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.42.tgz",
-          "integrity": "sha512-mJ58IKEBxa6SorCrIBSPu0OcEj94Y5+0/qUKqbNTTqfCOsPi6E5BEzMIgpf3Unrb59u+u5JBL0T/Sy7coOSO1A==",
-          "requires": {
-            "base64url": "^3.0.1",
-            "borc": "^2.1.2",
-            "canonicalize": "^1.0.3",
-            "cbor": "^5.1.0"
-          }
-        }
-      }
-    },
-    "@transmute/did-key-common": {
-      "version": "0.3.0-unstable.5",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.3.0-unstable.5.tgz",
-      "integrity": "sha512-8g8rPwzw8phRcO6j7Pdef7POB8Q+2mQRg+7rB6PX1wqxsAR6qFsaQRN5q1Odb6UOih1bZ2Dbnas1eArp6lNoSQ==",
-      "requires": {
-        "@did-core/data-model": "^0.1.1-unstable.13",
-        "@did-core/did-ld-json": "^0.1.1-unstable.13",
-        "@transmute/did-context": "^0.6.1-unstable.36",
-        "@transmute/ld-key-pair": "^0.6.1-unstable.36",
-        "@transmute/security-context": "^0.6.1-unstable.36"
-      },
-      "dependencies": {
-        "@transmute/ld-key-pair": {
-          "version": "0.6.1-unstable.37",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.6.1-unstable.37.tgz",
-          "integrity": "sha512-DcTpEruAQBfOd2laZkg3uCQ+67Y7dw2hsvo42NAQ5tItCIx5AClP7zccri7T2JUcfDUFaE32z/BLTMEKYt3XZQ=="
-        },
-        "@transmute/security-context": {
-          "version": "0.6.1-unstable.37",
-          "resolved": "https://registry.npmjs.org/@transmute/security-context/-/security-context-0.6.1-unstable.37.tgz",
-          "integrity": "sha512-GtLmG65qlORrz/2S4I74DT+vA4+qXsFxrMr0cNOXjUqZBd/AW1PTrFnryLF9907BfoiD58HC9qb1WVGWjSlBYw=="
-        }
-      }
-    },
-    "@transmute/did-key-ed25519": {
-      "version": "0.3.0-unstable.5",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.3.0-unstable.5.tgz",
-      "integrity": "sha512-yYnuCEZMVa7b+zmYgKby+49Rgnq045RWoR5ddG9n6UxDowFxrKuwZeN9imInCZcBY9mzYXm2yutqTXULuptUow==",
-      "requires": {
-        "@transmute/did-key-common": "^0.3.0-unstable.5",
-        "@transmute/ed25519-key-pair": "^0.6.1-unstable.37"
-      },
-      "dependencies": {
-        "@transmute/ed25519-key-pair": {
-          "version": "0.6.1-unstable.37",
-          "resolved": "https://registry.npmjs.org/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.6.1-unstable.37.tgz",
-          "integrity": "sha512-l34yzE/QnQwmdk5xY9g2kD55e4XPp/jTZQzPu7I6J4Ar+bMaL/0RLL/pgvwyI7qUpsddxRf4WPZCCcZveqPcdA==",
-          "requires": {
-            "@stablelib/ed25519": "^1.0.1",
-            "@transmute/ld-key-pair": "^0.6.1-unstable.37",
-            "@transmute/x25519-key-pair": "^0.6.1-unstable.37"
-          }
-        },
-        "@transmute/ld-key-pair": {
-          "version": "0.6.1-unstable.37",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.6.1-unstable.37.tgz",
-          "integrity": "sha512-DcTpEruAQBfOd2laZkg3uCQ+67Y7dw2hsvo42NAQ5tItCIx5AClP7zccri7T2JUcfDUFaE32z/BLTMEKYt3XZQ=="
-        },
-        "@transmute/x25519-key-pair": {
-          "version": "0.6.1-unstable.37",
-          "resolved": "https://registry.npmjs.org/@transmute/x25519-key-pair/-/x25519-key-pair-0.6.1-unstable.37.tgz",
-          "integrity": "sha512-j6zR9IoJmgVhUCVH8YVGpsgQf99SxPKZ00LGnUheBAQzgj2lULGBQ44G+GqBCdzfT0qweptTfp1RjqqHEpizeA==",
-          "requires": {
-            "@stablelib/x25519": "^1.0.0",
-            "@transmute/ld-key-pair": "^0.6.1-unstable.37"
-          }
-        }
-      }
-    },
-    "@transmute/did-key-x25519": {
-      "version": "0.2.1-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.42.tgz",
-      "integrity": "sha512-pInHZaepvjmfym1fBDrdbL5isUVbYHR1nYBsH3uD9EPn7SwZfEBe0Vg9hUop81b4x/6+VVWuGm2dIhpVBxsRPQ==",
-      "requires": {
-        "@stablelib/ed25519": "^1.0.1",
-        "@stablelib/x25519": "^1.0.0",
-        "@transmute/did-key-cipher": "^0.2.1-unstable.42",
-        "@transmute/did-key-common": "^0.2.1-unstable.42",
-        "@trust/keyto": "^1.0.1",
-        "base64url": "^3.0.1",
-        "bs58": "^4.0.1",
-        "canonicalize": "^1.0.1"
-      },
-      "dependencies": {
-        "@transmute/did-key-common": {
-          "version": "0.2.1-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.42.tgz",
-          "integrity": "sha512-mJ58IKEBxa6SorCrIBSPu0OcEj94Y5+0/qUKqbNTTqfCOsPi6E5BEzMIgpf3Unrb59u+u5JBL0T/Sy7coOSO1A==",
-          "requires": {
-            "base64url": "^3.0.1",
-            "borc": "^2.1.2",
-            "canonicalize": "^1.0.3",
-            "cbor": "^5.1.0"
-          }
-        }
-      }
-    },
-    "@transmute/ed25519-key-pair": {
-      "version": "0.7.0-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.7.0-unstable.42.tgz",
-      "integrity": "sha512-bavpT49M4TEz9o80tHT4b5U78lTirJoNLh19pXEgobgdAzqCoEeoN9pdG09XgLDzzGo/JO6ymOJjO4Os9/gKMw==",
-      "requires": {
-        "@stablelib/ed25519": "^1.0.1",
-        "@transmute/ld-key-pair": "^0.7.0-unstable.42",
-        "@transmute/x25519-key-pair": "^0.7.0-unstable.42"
-      },
-      "dependencies": {
-        "@transmute/ld-key-pair": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-nYo+KwOr/P8cXTbueBQjjaNASJkhzpbeu2sN7UBdT1kLDD5Ngrkb7pKD5jMSUudY8mIn+Chn9cTzQ/uEa3TDUw=="
-        },
-        "@transmute/x25519-key-pair": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/x25519-key-pair/-/x25519-key-pair-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-QjqbS9SwUK4AGhNVEcNVT8XYCKDv/DiucZsSmRWNhX7/FV/V+h2B7k6/KZa8LvkhMTkSsORQs8y1ecv3yIIMXQ==",
-          "requires": {
-            "@stablelib/x25519": "^1.0.0",
-            "@transmute/ld-key-pair": "^0.7.0-unstable.42"
-          }
-        }
-      }
     },
     "@transmute/jose-ld": {
       "version": "0.7.0-unstable.28",
@@ -2782,39 +1989,6 @@
         "@stablelib/xchacha20poly1305": "^1.0.0",
         "base64url": "^3.0.1",
         "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "@transmute/json-web-signature": {
-      "version": "0.7.0-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/json-web-signature/-/json-web-signature-0.7.0-unstable.42.tgz",
-      "integrity": "sha512-MEnlUW6NbwA/b5pPOAjXBRY7uwaaBs5HGL2+sZgszy9+EG4GEAQMxZk3PB2PDigc+TDmQVY+F/0NH+HE/e1TIQ==",
-      "requires": {
-        "@transmute/bls12381-key-pair": "^0.7.0-unstable.42",
-        "@transmute/ed25519-key-pair": "^0.7.0-unstable.42",
-        "@transmute/jose-ld": "^0.7.0-unstable.42",
-        "@transmute/secp256k1-key-pair": "^0.7.0-unstable.42",
-        "@transmute/security-context": "^0.7.0-unstable.42",
-        "@transmute/web-crypto-key-pair": "^0.7.0-unstable.42",
-        "jsonld": "^5.2.0"
-      },
-      "dependencies": {
-        "@transmute/jose-ld": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-Qfz2njE4hy26qhnUBUWOVr0vvWKz0QpO2KUByri7IL8Im7Ih9GylLVMQElkWyh2mAK/XzDVe1rAqts5ywGbFAA==",
-          "requires": {
-            "@peculiar/webcrypto": "^1.1.6",
-            "@stablelib/aes-kw": "^1.0.0",
-            "@stablelib/xchacha20poly1305": "^1.0.0",
-            "base64url": "^3.0.1",
-            "web-streams-polyfill": "^3.0.3"
-          }
-        },
-        "@transmute/security-context": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/security-context/-/security-context-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-yM5WRojmPa95r83qWz/4e5WzTQ8129St/o61Z13XWRNkdKidjOd9s/lfUdaNmmxZBCw22dBWMZOG6NZo4tUp+A=="
-        }
       }
     },
     "@transmute/jsonld-document-loader": {
@@ -2829,23 +2003,6 @@
       "version": "0.7.0-unstable.28",
       "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.28.tgz",
       "integrity": "sha512-apNOgjpHRHq7BRPoXM1BDaiVCzTjnQWPiZoSUbav5mecOjSjmWEkk3lY30EVXBVzfddVIRsgVb2MIYqFchE4aA=="
-    },
-    "@transmute/secp256k1-key-pair": {
-      "version": "0.7.0-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/secp256k1-key-pair/-/secp256k1-key-pair-0.7.0-unstable.42.tgz",
-      "integrity": "sha512-N6u4LGS4OGnoDYC2QaN6+ZKBD1za50sF4JRE5U99wmntPJ42DXxbiucGZ0vz3CAdNG/85Aw6gxBJtAacY31lgQ==",
-      "requires": {
-        "@bitauth/libauth": "^1.18.1",
-        "@transmute/ld-key-pair": "^0.7.0-unstable.42",
-        "secp256k1": "^4.0.2"
-      },
-      "dependencies": {
-        "@transmute/ld-key-pair": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-nYo+KwOr/P8cXTbueBQjjaNASJkhzpbeu2sN7UBdT1kLDD5Ngrkb7pKD5jMSUudY8mIn+Chn9cTzQ/uEa3TDUw=="
-        }
-      }
     },
     "@transmute/security-context": {
       "version": "0.7.0-unstable.28",
@@ -2875,23 +2032,6 @@
         "@transmute/security-context": "^0.7.0-unstable.28"
       }
     },
-    "@transmute/web-crypto-key-pair": {
-      "version": "0.7.0-unstable.42",
-      "resolved": "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.7.0-unstable.42.tgz",
-      "integrity": "sha512-y5auPBaavZi7HAZ81Fq1zEnDHM9CPfl7wpwXEOkvmGLRUAiXkgn/ExRMGycwaR3gGqjSqR8df16SZoLftUTT/A==",
-      "requires": {
-        "@peculiar/webcrypto": "^1.1.6",
-        "@transmute/ld-key-pair": "^0.7.0-unstable.42",
-        "big-integer": "^1.6.48"
-      },
-      "dependencies": {
-        "@transmute/ld-key-pair": {
-          "version": "0.7.0-unstable.42",
-          "resolved": "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.42.tgz",
-          "integrity": "sha512-nYo+KwOr/P8cXTbueBQjjaNASJkhzpbeu2sN7UBdT1kLDD5Ngrkb7pKD5jMSUudY8mIn+Chn9cTzQ/uEa3TDUw=="
-        }
-      }
-    },
     "@transmute/x25519-key-pair": {
       "version": "0.7.0-unstable.28",
       "resolved": "https://registry.npmjs.org/@transmute/x25519-key-pair/-/x25519-key-pair-0.7.0-unstable.28.tgz",
@@ -2899,52 +2039,6 @@
       "requires": {
         "@stablelib/x25519": "^1.0.0",
         "@transmute/ld-key-pair": "^0.7.0-unstable.28"
-      }
-    },
-    "@truffle/hdwallet-provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-2.0.3.tgz",
-      "integrity": "sha512-jT7X9P8hmXDaoem6GPzYhZ1p6PnW2l7sPMtVe7JCDXZTlv8hMy/ZfcyEppEoNqpad8vjWWpvGuETvyPpBEbLOw==",
-      "requires": {
-        "@ethereumjs/common": "^2.4.0",
-        "@ethereumjs/tx": "^3.3.0",
-        "eth-sig-util": "^3.0.1",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereum-protocol": "^1.0.1",
-        "ethereumjs-util": "^6.1.0",
-        "ethereumjs-wallet": "^1.0.1",
-        "web3-provider-engine": "16.0.3"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "@trust/keyto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
-      "integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-      "requires": {
-        "asn1.js": "^5.2.0",
-        "base64url": "^3.0.1",
-        "elliptic": "^6.5.2"
       }
     },
     "@types/asn1js": {
@@ -3001,19 +2095,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "requires": {
-        "bson": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3026,12 +2107,14 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -3040,6 +2123,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
@@ -3049,25 +2133,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
-    },
-    "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "16.11.10",
@@ -3165,26 +2230,14 @@
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
-    },
-    "@types/webidl-conversions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
-      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
-    },
-    "@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
       "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -3192,7 +2245,8 @@
     "@types/yargs-parser": {
       "version": "20.2.1",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "dev": true
     },
     "@typescript-eslint/parser": {
       "version": "4.33.0",
@@ -3290,43 +2344,11 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
-    "@waiting/base64": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@waiting/base64/-/base64-4.2.9.tgz",
-      "integrity": "sha512-yzt9ih63oePux/sQM8Df6DTv1IeXGByaHrFiJoPszk0LaJwIGJ3IKhKhT/O6YMo2RignlP2cfxoo1lGmKZPIgQ=="
-    },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "optional": true
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
-    "abstract-leveldown": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-      "requires": {
-        "xtend": "~4.0.0"
-      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -3365,11 +2387,6 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
-    "aes-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
-    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3407,23 +2424,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "amazon-qldb-driver-nodejs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-2.2.0.tgz",
-      "integrity": "sha512-6YuiS8S5C/B3kRjDyWQsOOnPxfMIhpO94k2IBlUKt+g4kXiHodoo7PpBOHt7pQRfjlqnBuGF4W+2yaLC8UEVyA==",
-      "requires": {
-        "@types/node": "^12.0.2",
-        "ion-hash-js": "^2.0.0",
-        "semaphore-async-await": "^1.5.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.45.tgz",
-          "integrity": "sha512-1Jg2Qv5tuxBqgQV04+wO5u+wmSHbHgpORCJdeCLM+E+YdPElpdHhgywU+M1V1InL8rfOtpqtOjswk+uXTKwx7w=="
-        }
-      }
-    },
     "anser": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
@@ -3434,23 +2434,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
-    },
-    "ansi-escape-sequences": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-      "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-      "optional": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "optional": true
-        }
-      }
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -3482,15 +2465,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "any-signal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
-      "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "native-abort-controller": "^1.0.3"
-      }
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -3498,44 +2472,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "argparse": {
@@ -3555,15 +2491,6 @@
       "requires": {
         "@babel/runtime": "^7.10.2",
         "@babel/runtime-corejs3": "^7.10.2"
-      }
-    },
-    "array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "optional": true,
-      "requires": {
-        "typical": "^2.6.1"
       }
     },
     "array-flatten": {
@@ -3679,34 +2606,10 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "async-eventemitter": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-      "requires": {
-        "async": "^2.4.0"
-      }
-    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
-    "async-mutex": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.6.tgz",
-      "integrity": "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -3924,33 +2827,6 @@
         "resolve": "^1.12.0"
       }
     },
-    "babel-plugin-polyfill-corejs2": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
-      "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
-      "requires": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "semver": "^6.1.1"
-      }
-    },
-    "babel-plugin-polyfill-corejs3": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
-      "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "core-js-compat": "^3.21.0"
-      }
-    },
-    "babel-plugin-polyfill-regenerator": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
-      "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1"
-      }
-    },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
@@ -3981,18 +2857,11 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-      "requires": {
-        "precond": "0.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base-x": {
       "version": "3.0.9",
@@ -4020,11 +2889,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -4040,86 +2904,10 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        }
-      }
-    },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "blakejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
-    },
-    "blob-to-it": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.4.tgz",
-      "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
-      "requires": {
-        "browser-readablestream-to-it": "^1.0.3"
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "optional": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -4186,31 +2974,11 @@
         }
       }
     },
-    "borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "iso-url": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-          "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4234,11 +3002,6 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
-    },
-    "browser-readablestream-to-it": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -4314,30 +3077,6 @@
         "pako": "~1.0.5"
       }
     },
-    "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
-      "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001311",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz",
-          "integrity": "sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A=="
-        },
-        "electron-to-chromium": {
-          "version": "1.4.68",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz",
-          "integrity": "sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA=="
-        }
-      }
-    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -4364,19 +3103,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "bson": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-      "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -4414,12 +3140,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-    },
-    "builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-      "optional": true
     },
     "bytes": {
       "version": "3.1.0",
@@ -4488,24 +3208,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
       "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg=="
     },
-    "canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-      "requires": {
-        "bignumber.js": "^9.0.1",
-        "nofilter": "^1.0.4"
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4530,20 +3236,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "optional": true
-    },
-    "checkpoint-store": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
-      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
-      "requires": {
-        "functional-red-black-tree": "^1.0.1"
-      }
-    },
     "chokidar": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -4567,7 +3259,8 @@
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
     },
     "cids": {
       "version": "0.7.5",
@@ -4617,21 +3310,6 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "optional": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "optional": true
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -4642,11 +3320,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -4676,11 +3349,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -4714,43 +3382,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-line-args": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-      "optional": true,
-      "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^1.0.3",
-        "typical": "^2.6.1"
-      }
-    },
-    "command-line-commands": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
-      "integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
-      "optional": true,
-      "requires": {
-        "array-back": "^2.0.0"
-      }
-    },
-    "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
-      "optional": true,
-      "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "table-layout": "^0.4.2",
-        "typical": "^2.6.1"
-      }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4759,17 +3390,13 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -4799,11 +3426,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "convert-hrtime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-2.0.0.tgz",
-      "integrity": "sha1-Gb+yyRYvnhHC8Ewsed4rfoCVxic="
-    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -4831,22 +3453,6 @@
       "version": "3.19.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
       "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg=="
-    },
-    "core-js-compat": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.0.tgz",
-      "integrity": "sha512-OSXseNPSK2OPJa6GdtkMz/XxeXx8/CJvfhQWTqd6neuUraujcL4jVsjkLQz1OWnax8xVQJnRPe0V2jqNWORA+A==",
-      "requires": {
-        "browserslist": "^4.19.1",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-        }
-      }
     },
     "core-js-pure": {
       "version": "3.19.1",
@@ -4928,22 +3534,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cross-fetch": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.5.tgz",
-      "integrity": "sha512-xqYAhQb4NhCJSRym03dwxpP1bYXpK3y7UN83Bo2WFi3x1Zmzn0SL/6xGoPr+gpt4WmNrgCCX3HPysvOwFOW36w==",
-      "requires": {
-        "node-fetch": "2.6.1",
-        "whatwg-fetch": "2.0.4"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "cross-spawn": {
@@ -5138,11 +3728,6 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5160,14 +3745,6 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
-    "deferred-leveldown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-      "requires": {
-        "abstract-leveldown": "~2.6.0"
-      }
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -5180,21 +3757,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
-    },
-    "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -5214,11 +3776,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -5256,31 +3813,6 @@
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
-      }
-    },
-    "dns-over-http-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
-      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
-      "requires": {
-        "debug": "^4.3.1",
-        "native-fetch": "^3.0.0",
-        "receptacle": "^1.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "doctrine": {
@@ -5371,14 +3903,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "electron-fetch": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
-      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
-      "requires": {
-        "encoding": "^0.1.13"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.3.907",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.907.tgz",
@@ -5414,7 +3938,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -5449,19 +3974,6 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
-      }
-    },
-    "err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-    },
-    "errno": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "requires": {
-        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -6065,11 +4577,6 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -6135,11 +4642,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
-    "estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6150,19 +4652,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eth-block-tracker": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-4.4.3.tgz",
-      "integrity": "sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw==",
-      "requires": {
-        "@babel/plugin-transform-runtime": "^7.5.5",
-        "@babel/runtime": "^7.5.5",
-        "eth-query": "^2.1.0",
-        "json-rpc-random-id": "^1.0.1",
-        "pify": "^3.0.0",
-        "safe-event-emitter": "^1.0.1"
-      }
     },
     "eth-ens-namehash": {
       "version": "2.0.8",
@@ -6177,129 +4666,6 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        }
-      }
-    },
-    "eth-json-rpc-filters": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.2.tgz",
-      "integrity": "sha512-DGtqpLU7bBg63wPMWg1sCpkKCf57dJ+hj/k3zF26anXMzkmtSBDExL8IhUu7LUd34f0Zsce3PYNO2vV2GaTzaw==",
-      "requires": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "async-mutex": "^0.2.6",
-        "eth-json-rpc-middleware": "^6.0.0",
-        "eth-query": "^2.1.2",
-        "json-rpc-engine": "^6.1.0",
-        "pify": "^5.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
-        }
-      }
-    },
-    "eth-json-rpc-infura": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-5.1.0.tgz",
-      "integrity": "sha512-THzLye3PHUSGn1EXMhg6WTLW9uim7LQZKeKaeYsS9+wOBcamRiCQVGHa6D2/4P0oS0vSaxsBnU/J6qvn0MPdow==",
-      "requires": {
-        "eth-json-rpc-middleware": "^6.0.0",
-        "eth-rpc-errors": "^3.0.0",
-        "json-rpc-engine": "^5.3.0",
-        "node-fetch": "^2.6.0"
-      },
-      "dependencies": {
-        "json-rpc-engine": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
-          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
-          "requires": {
-            "eth-rpc-errors": "^3.0.0",
-            "safe-event-emitter": "^1.0.1"
-          }
-        }
-      }
-    },
-    "eth-json-rpc-middleware": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-6.0.0.tgz",
-      "integrity": "sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ==",
-      "requires": {
-        "btoa": "^1.2.1",
-        "clone": "^2.1.1",
-        "eth-query": "^2.1.2",
-        "eth-rpc-errors": "^3.0.0",
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-util": "^5.1.2",
-        "json-rpc-engine": "^5.3.0",
-        "json-stable-stringify": "^1.0.1",
-        "node-fetch": "^2.6.1",
-        "pify": "^3.0.0",
-        "safe-event-emitter": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "eth-sig-util": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-          "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-          "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-            "ethereumjs-util": "^5.1.1"
-          }
-        },
-        "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-              "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.3"
-              }
-            }
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "json-rpc-engine": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
-          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
-          "requires": {
-            "eth-rpc-errors": "^3.0.0",
-            "safe-event-emitter": "^1.0.1"
-          }
         }
       }
     },
@@ -6323,60 +4689,6 @@
         }
       }
     },
-    "eth-query": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
-      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
-      "requires": {
-        "json-rpc-random-id": "^1.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "eth-rpc-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
-      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
-      "requires": {
-        "fast-safe-stringify": "^2.0.6"
-      }
-    },
-    "eth-sig-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
-      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
-      "requires": {
-        "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
-      }
-    },
     "ethereum-bloom-filters": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
@@ -6384,11 +4696,6 @@
       "requires": {
         "js-sha3": "^0.8.0"
       }
-    },
-    "ethereum-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereum-cryptography": {
       "version": "0.1.3",
@@ -6410,145 +4717,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "ethereum-protocol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
-      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
-    },
-    "ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "ethereumjs-account": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
-      "requires": {
-        "ethereumjs-util": "^5.0.0",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
-    "ethereumjs-block": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
-      "requires": {
-        "async": "^2.0.1",
-        "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "^1.2.2",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
-    "ethereumjs-common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
-    },
-    "ethereumjs-tx": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-      "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        }
       }
     },
     "ethereumjs-util": {
@@ -6573,104 +4741,6 @@
         }
       }
     },
-    "ethereumjs-vm": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
-      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
-      "requires": {
-        "async": "^2.1.2",
-        "async-eventemitter": "^0.2.2",
-        "ethereumjs-account": "^2.0.3",
-        "ethereumjs-block": "~2.2.0",
-        "ethereumjs-common": "^1.1.0",
-        "ethereumjs-util": "^6.0.0",
-        "fake-merkle-patricia-tree": "^1.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "merkle-patricia-tree": "^2.3.2",
-        "rustbn.js": "~0.2.0",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-block": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-          "requires": {
-            "async": "^2.0.1",
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-tx": "^2.1.1",
-            "ethereumjs-util": "^5.0.0",
-            "merkle-patricia-tree": "^2.1.2"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
-              }
-            }
-          }
-        },
-        "ethereumjs-tx": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-          "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "ethereumjs-wallet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "requires": {
-        "aes-js": "^3.1.2",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^7.1.2",
-        "randombytes": "^2.1.0",
-        "scrypt-js": "^3.0.1",
-        "utf8": "^3.0.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -6686,20 +4756,6 @@
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.4",
@@ -6849,28 +4905,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "optional": true,
-      "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -6885,23 +4919,10 @@
         "source-map-support": "^0.5.19"
       }
     },
-    "fake-merkle-patricia-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
-      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
-      "requires": {
-        "checkpoint-store": "^1.1.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -6927,11 +4948,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -6950,28 +4966,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "optional": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "optional": true
-        }
-      }
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6980,11 +4974,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -7016,27 +5005,6 @@
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
-      }
-    },
-    "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-      "optional": true,
-      "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "optional": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
       }
     },
     "find-root": {
@@ -7120,45 +5088,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7168,55 +5105,8 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7239,11 +5129,6 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
-    },
-    "get-iterator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-orientation": {
       "version": "1.1.2",
@@ -7284,19 +5169,11 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "git-config": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/git-config/-/git-config-0.0.7.tgz",
-      "integrity": "sha1-qcij7wendsPXImE1bYtye2IgKyg=",
-      "optional": true,
-      "requires": {
-        "iniparser": "~1.0.5"
-      }
-    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7390,27 +5267,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "optional": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7469,11 +5325,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-    },
     "hash-base": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
@@ -7498,16 +5349,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hdkey": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-2.0.1.tgz",
-      "integrity": "sha512-c+tl9PHG9/XkGgG0tD7CJpRVaE0jfZizDNmnErUAKQ4EjQSOcOUcV3EN9ZEZS8pZ4usaeiiK0H7stzuzna8feA==",
-      "requires": {
-        "bs58check": "^2.1.2",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^4.0.0"
       }
     },
     "he": {
@@ -7685,14 +5526,6 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
-    "ignore-walk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "image-size": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
@@ -7700,11 +5533,6 @@
       "requires": {
         "queue": "6.0.2"
       }
-    },
-    "immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -7735,6 +5563,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7744,78 +5573,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "iniparser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz",
-      "integrity": "sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=",
-      "optional": true
-    },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "optional": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -7827,776 +5584,10 @@
         "side-channel": "^1.0.4"
       }
     },
-    "ion-hash-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ion-hash-js/-/ion-hash-js-2.0.0.tgz",
-      "integrity": "sha512-5E9YmRhxn1XGv/qftwqma1iTM0fWgfLbH8qWf6OCHIGppft7uQ+ClUkI5swNB4n9IDZ7GL0rFHINW2oPrurr5Q=="
-    },
-    "ion-js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ion-js/-/ion-js-4.2.1.tgz",
-      "integrity": "sha512-4AxcCHQweLWBaAFViR8aBL1svaAHW53lnF5JruhZwzbd4xpUXxMGx8JftrAuC+FEvArZ3VhfHsS679l8XJc47Q=="
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
-    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    },
-    "ipfs-core-types": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.3.1.tgz",
-      "integrity": "sha512-xPBsowS951RsuskMo86AWz9y4ReaBot1YsjOhZvKl8ORd8taxIBTT72LnEPwIZ2G24U854Zjxvd/qUMqO14ivg==",
-      "requires": {
-        "cids": "^1.1.5",
-        "multiaddr": "^8.0.0",
-        "peer-id": "^0.14.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipfs-core-utils": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.7.2.tgz",
-      "integrity": "sha512-d7T72GxvhNN+tEHsJjxI5Y4LQVdMMbSwNbWB6nVsIHUEdwm3w85L2u1E/ctNd9aaNGvoBwEcnIZhSmqhMf7stw==",
-      "requires": {
-        "any-signal": "^2.1.2",
-        "blob-to-it": "^1.0.1",
-        "browser-readablestream-to-it": "^1.0.1",
-        "cids": "^1.1.5",
-        "err-code": "^2.0.3",
-        "ipfs-core-types": "^0.3.1",
-        "ipfs-utils": "^6.0.1",
-        "it-all": "^1.0.4",
-        "it-map": "^1.0.4",
-        "it-peekable": "^1.0.1",
-        "multiaddr": "^8.0.0",
-        "multiaddr-to-uri": "^6.0.0",
-        "parse-duration": "^0.4.4",
-        "timeout-abort-controller": "^1.1.1",
-        "uint8arrays": "^2.1.3"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipfs-http-client": {
-      "version": "49.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-49.0.4.tgz",
-      "integrity": "sha512-qgWbkcB4glQrUkE2tZR+GVXyrO6aJyspWBjyct/6TzrhCHx7evjz+kUTK+wNm4S9zccUePEml5VNZUmUhoQtbA==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "any-signal": "^2.1.2",
-        "bignumber.js": "^9.0.1",
-        "cids": "^1.1.5",
-        "debug": "^4.1.1",
-        "form-data": "^3.0.0",
-        "ipfs-core-types": "^0.3.1",
-        "ipfs-core-utils": "^0.7.2",
-        "ipfs-utils": "^6.0.1",
-        "ipld-block": "^0.11.0",
-        "ipld-dag-cbor": "^0.17.0",
-        "ipld-dag-pb": "^0.20.0",
-        "ipld-raw": "^6.0.0",
-        "it-last": "^1.0.4",
-        "it-map": "^1.0.4",
-        "it-tar": "^1.2.2",
-        "it-to-stream": "^0.1.2",
-        "merge-options": "^3.0.4",
-        "multiaddr": "^8.0.0",
-        "multibase": "^4.0.2",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.2",
-        "nanoid": "^3.1.12",
-        "native-abort-controller": "^1.0.3",
-        "parse-duration": "^0.4.4",
-        "stream-to-it": "^0.2.2",
-        "uint8arrays": "^2.1.3"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipfs-unixfs": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.4.tgz",
-      "integrity": "sha512-b8dL8DZSwv0G3WTy8XnH1+Vzj/UydNI4yK/7/j3Ywyx+3yAQW566bdgaW1zvEFWTT3tBK1h3iJrRNHRs3CnBJA==",
-      "requires": {
-        "err-code": "^2.0.0",
-        "protons": "^2.0.0"
-      }
-    },
-    "ipfs-utils": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-6.0.8.tgz",
-      "integrity": "sha512-mDDQaDisI/uWk+X08wyw+jBcq76IXwMjgyaoyEgJDb/Izb+QbBCSJjo9q+EvbMxh6/l6q0NiAfbbsxEyQYPW9w==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "any-signal": "^2.1.0",
-        "buffer": "^6.0.1",
-        "electron-fetch": "^1.7.2",
-        "err-code": "^3.0.1",
-        "is-electron": "^2.2.0",
-        "iso-url": "^1.0.0",
-        "it-glob": "~0.0.11",
-        "it-to-stream": "^1.0.0",
-        "merge-options": "^3.0.4",
-        "nanoid": "^3.1.20",
-        "native-abort-controller": "^1.0.3",
-        "native-fetch": "^3.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-to-it": "^0.2.2"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "err-code": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-          "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
-        },
-        "it-to-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
-          "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
-          "requires": {
-            "buffer": "^6.0.3",
-            "fast-fifo": "^1.0.0",
-            "get-iterator": "^1.0.2",
-            "p-defer": "^3.0.0",
-            "p-fifo": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        }
-      }
-    },
-    "ipld-block": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.11.1.tgz",
-      "integrity": "sha512-sDqqLqD5qh4QzGq6ssxLHUCnH4emCf/8F8IwjQM2cjEEIEHMUj57XhNYgmGbemdYPznUhffxFGEHsruh5+HQRw==",
-      "requires": {
-        "cids": "^1.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipld-dag-cbor": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.1.tgz",
-      "integrity": "sha512-Bakj/cnxQBdscORyf4LRHxQJQfoaY8KWc7PWROQgX+aw5FCzBt8ga0VM/59K+ABOznsqNvyLR/wz/oYImOpXJw==",
-      "requires": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "is-circular": "^1.0.2",
-        "multicodec": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^2.1.3"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
-      "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
-      "requires": {
-        "cids": "^1.0.0",
-        "class-is": "^1.1.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0",
-        "protons": "^2.0.0",
-        "reset": "^0.1.0",
-        "run": "^1.4.0",
-        "stable": "^0.1.8",
-        "uint8arrays": "^1.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "multicodec": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-              "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-              "requires": {
-                "uint8arrays": "^3.0.0",
-                "varint": "^6.0.0"
-              }
-            },
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.3.tgz",
-          "integrity": "sha512-0tOH2Gtio39uO41o+2xl9UhRkCWxU5ZmZSbFCh/OjGzkWJI8e6lkN/s4Mj1YfyWoBod+2+S3W+6wO6nhkwN8pA==",
-          "requires": {
-            "uint8arrays": "1.1.0",
-            "varint": "^6.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-          "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-          "requires": {
-            "multibase": "^3.0.0",
-            "web-encoding": "^1.0.2"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
-              "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
-              "requires": {
-                "@multiformats/base-x": "^4.0.1",
-                "web-encoding": "^1.0.6"
-              }
-            }
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "ipld-raw": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
-      "integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
-      "requires": {
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "multicodec": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-              "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-              "requires": {
-                "uint8arrays": "^3.0.0",
-                "varint": "^6.0.0"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.3.tgz",
-          "integrity": "sha512-0tOH2Gtio39uO41o+2xl9UhRkCWxU5ZmZSbFCh/OjGzkWJI8e6lkN/s4Mj1YfyWoBod+2+S3W+6wO6nhkwN8pA==",
-          "requires": {
-            "uint8arrays": "1.1.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
-              "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
-              "requires": {
-                "@multiformats/base-x": "^4.0.1",
-                "web-encoding": "^1.0.6"
-              }
-            },
-            "uint8arrays": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-              "requires": {
-                "multibase": "^3.0.0",
-                "web-encoding": "^1.0.2"
-              }
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -8642,11 +5633,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
-    "is-circular": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
-    },
     "is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -8663,25 +5649,16 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
-    "is-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
-    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-function": {
       "version": "1.0.2",
@@ -8719,14 +5696,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
-    },
-    "is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "requires": {
-        "ip-regex": "^4.0.0"
-      }
     },
     "is-nan": {
       "version": "1.3.2",
@@ -8852,26 +5821,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "iso-constants": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
-      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
-    },
-    "iso-random-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
-      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
-      "requires": {
-        "events": "^3.3.0",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "iso-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
-      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -8980,113 +5931,6 @@
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
-      }
-    },
-    "it-all": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
-    },
-    "it-concat": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.3.tgz",
-      "integrity": "sha512-sjeZQ1BWQ9U/W2oI09kZgUyvSWzQahTkOkLIsnEPgyqZFaF9ME5gV6An4nMjlyhXKWQMKEakQU8oRHs2SdmeyA==",
-      "requires": {
-        "bl": "^4.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
-    "it-glob": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
-      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
-      "requires": {
-        "@types/minimatch": "^3.0.4",
-        "minimatch": "^3.0.4"
-      }
-    },
-    "it-last": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.6.tgz",
-      "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
-    },
-    "it-map": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
-      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
-    },
-    "it-peekable": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.3.tgz",
-      "integrity": "sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ=="
-    },
-    "it-reader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
-      "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
-      "requires": {
-        "bl": "^4.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
-    "it-tar": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
-      "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
-      "requires": {
-        "bl": "^4.0.0",
-        "buffer": "^5.4.3",
-        "iso-constants": "^0.1.2",
-        "it-concat": "^1.0.0",
-        "it-reader": "^2.0.0",
-        "p-defer": "^3.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
-    "it-to-stream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.2.tgz",
-      "integrity": "sha512-DTB5TJRZG3untmZehcaFN0kGWl2bNv7tnJRgQHAO9QEt8jfvVRrebZtnD5NZd4SCj4WVPjl0LSrugNWE/UaZRQ==",
-      "requires": {
-        "buffer": "^5.6.0",
-        "fast-fifo": "^1.0.0",
-        "get-iterator": "^1.0.2",
-        "p-defer": "^3.0.0",
-        "p-fifo": "^1.0.0",
-        "readable-stream": "^3.6.0"
       }
     },
     "jest": {
@@ -9496,6 +6340,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.2.tgz",
       "integrity": "sha512-nzTZ5nJ+FabuZPH2YVci7SZIHpvtNRHPt8+vipLkCnAgXGjVzHm7XJWdnNqXbAkExIgiKeVEkVMNZOZE/LeiIg==",
+      "dev": true,
       "requires": {
         "@jest/environment": "^27.4.2",
         "@jest/fake-timers": "^27.4.2",
@@ -9714,6 +6559,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.2.tgz",
       "integrity": "sha512-OMRqRNd9E0DkBLZpFtZkAGYOXl6ZpoMtQJWTAREJKDOFa0M6ptB7L67tp+cszMBkvSgKOhNtQp2Vbcz3ZZKo/w==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^27.4.2",
@@ -9730,6 +6576,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -9738,6 +6585,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -9747,6 +6595,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -9754,17 +6603,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -9775,6 +6627,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.2.tgz",
       "integrity": "sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==",
+      "dev": true,
       "requires": {
         "@jest/types": "^27.4.2",
         "@types/node": "*"
@@ -10172,6 +7025,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
       "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+      "dev": true,
       "requires": {
         "@jest/types": "^27.4.2",
         "@types/node": "*",
@@ -10185,6 +7039,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -10193,6 +7048,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -10202,6 +7058,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -10209,17 +7066,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -10418,11 +7278,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbi": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
-      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -10528,7 +7383,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -10540,30 +7396,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "json-rpc-engine": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
-      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
-      "requires": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "eth-rpc-errors": "^4.0.2"
-      },
-      "dependencies": {
-        "eth-rpc-errors": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
-          "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
-          "requires": {
-            "fast-safe-stringify": "^2.0.6"
-          }
-        }
-      }
-    },
-    "json-rpc-random-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -10573,14 +7405,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10592,14 +7416,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
     },
     "json5": {
       "version": "1.0.1",
@@ -10615,64 +7431,6 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
-      "requires": {
-        "@digitalbazaar/http-client": "^1.1.0",
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
-      }
-    },
-    "jsonld-checker": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/jsonld-checker/-/jsonld-checker-0.1.7.tgz",
-      "integrity": "sha512-AFBFjRttHzB5Q78SATl5Qhc3hQEnmiEqLuUIpfVx8bn5ODhO1M0IiV9PRPUMe6IZjedGWOZEmzieNIBs88EDVg==",
-      "requires": {
-        "jsonld": "^3.1.1",
-        "node-fetch": "^2.6.1"
-      },
-      "dependencies": {
-        "jsonld": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-3.3.2.tgz",
-          "integrity": "sha512-DXqG/fdiG7eJ8FzvSd58bW8DQsulQR/gjLYUz9PxBP/WTTpB2HzjjdxSAx5aBHewJ0RiFAV/QcqGCJjxHvuIzw==",
-          "requires": {
-            "canonicalize": "^1.0.1",
-            "lru-cache": "^5.1.1",
-            "object.fromentries": "^2.0.2",
-            "rdf-canonize": "^2.0.1",
-            "request": "^2.88.0",
-            "semver": "^6.3.0",
-            "xmldom": "0.1.19"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "rdf-canonize": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
-          "integrity": "sha512-/GVELjrfW8G/wS4QfDZ5Kq68cS1belVNJqZlcwiErerexeBUsgOINCROnP7UumWIBNdeCwTVLE9NVXMnRYK0lA==",
-          "requires": {
-            "semver": "^6.3.0",
-            "setimmediate": "^1.0.5"
-          }
-        }
       }
     },
     "jsprim": {
@@ -10784,11 +7542,6 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "keypair": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.4.tgz",
-      "integrity": "sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg=="
-    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -10808,31 +7561,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
-    },
-    "ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "3.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-          "requires": {
-            "data-uri-to-buffer": "^3.0.1",
-            "fetch-blob": "^2.1.1"
-          }
-        }
-      }
-    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -10846,119 +7574,6 @@
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
-      }
-    },
-    "level-codec": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-    },
-    "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "level-ws": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-      "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
-    "levelup": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-      "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
-        "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        }
       }
     },
     "leven": {
@@ -10975,31 +7590,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "libp2p-crypto": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.7.tgz",
-      "integrity": "sha512-Qb5o/3WFKF2j6mYSt4UBPyi2kbKl3jYV0podBJoJCw70DlpM5Xc+oh3fFY9ToSunu8aSQQ5GY8nutjXgX/uGRA==",
-      "requires": {
-        "err-code": "^3.0.1",
-        "is-typedarray": "^1.0.0",
-        "iso-random-stream": "^2.0.0",
-        "keypair": "^1.0.1",
-        "multiformats": "^9.4.5",
-        "node-forge": "^0.10.0",
-        "pem-jwk": "^2.0.0",
-        "protobufjs": "^6.11.2",
-        "secp256k1": "^4.0.0",
-        "uint8arrays": "^3.0.0",
-        "ursa-optional": "^0.10.1"
-      },
-      "dependencies": {
-        "err-code": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-          "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
-        }
       }
     },
     "lines-and-columns": {
@@ -11028,24 +7618,14 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "optional": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -11057,11 +7637,6 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -11080,6 +7655,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
@@ -11087,21 +7663,9 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
-      }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -11136,54 +7700,10 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
-    "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-      "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
-      }
-    },
-    "memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "requires": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        }
-      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -11196,69 +7716,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
-    "merkle-patricia-tree": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-      "requires": {
-        "async": "^1.4.2",
-        "ethereumjs-util": "^5.0.0",
-        "level-ws": "0.0.0",
-        "levelup": "^1.2.1",
-        "memdown": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -11268,6 +7725,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -11340,6 +7798,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11389,187 +7848,10 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
-    "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
-      "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
-        }
-      }
-    },
-    "mongodb-connection-string-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.2.tgz",
-      "integrity": "sha512-mZUXF6nUzRWk5J3h41MsPv13ukWlH4jOMSk6astVeoZ1EbdTJyF5I3wxKkvqBAOoVtzLgyEYUvDjrGdcPlKjAw==",
-      "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "requires": {
-            "punycode": "^2.1.1"
-          }
-        },
-        "webidl-conversions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-        },
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
-          }
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "multiaddr": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.1.2.tgz",
-      "integrity": "sha512-r13IzW8+Sv9zab9Gt8RPMIN2WkptIPq99EpAzg4IbJ/zTELhiEwXWr9bAmEatSCI4j/LSA6ESJzvz95JZ+ZYXQ==",
-      "requires": {
-        "cids": "^1.0.0",
-        "class-is": "^1.1.0",
-        "dns-over-http-resolver": "^1.0.0",
-        "err-code": "^2.0.3",
-        "is-ip": "^3.1.0",
-        "multibase": "^3.0.0",
-        "uint8arrays": "^1.1.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "4.0.6",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-              "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-              "requires": {
-                "@multiformats/base-x": "^4.0.1"
-              }
-            },
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
-          "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1",
-            "web-encoding": "^1.0.6"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "4.0.6",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-              "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-              "requires": {
-                "@multiformats/base-x": "^4.0.1"
-              }
-            },
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-          "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-          "requires": {
-            "multibase": "^3.0.0",
-            "web-encoding": "^1.0.2"
-          }
-        }
-      }
-    },
-    "multiaddr-to-uri": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-6.0.0.tgz",
-      "integrity": "sha512-OjpkVHOXEmIKMO8WChzzQ7aZQcSQX8squxmvtDbRpy7/QNmJ3Z7jv6qyD74C28QtaeNie8O8ngW2AkeiMmKP7A==",
-      "requires": {
-        "multiaddr": "^8.0.0"
-      }
     },
     "multibase": {
       "version": "0.6.1",
@@ -11587,11 +7869,6 @@
       "requires": {
         "varint": "^5.0.0"
       }
-    },
-    "multiformats": {
-      "version": "9.6.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
-      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "multihashes": {
       "version": "0.4.21",
@@ -11614,60 +7891,6 @@
         }
       }
     },
-    "multihashing-async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.4.tgz",
-      "integrity": "sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "err-code": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-          "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          }
-        }
-      }
-    },
-    "murmurhash3js-revisited": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "optional": true
-    },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-    },
     "nano-json-stream-parser": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
@@ -11677,16 +7900,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
-    },
-    "native-abort-controller": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
-      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ=="
-    },
-    "native-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw=="
     },
     "native-url": {
       "version": "0.3.4",
@@ -11702,131 +7915,10 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "optional": true
-    },
-    "neon-cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.4.0.tgz",
-      "integrity": "sha512-66HhHb8rk+zHSG64CI6jhyOQqpibBAald8ObdQPCjXcCjzSEVnkQHutUE8dyNlHRNT7xLfrZGkDbtwrYh2p+6w==",
-      "optional": true,
-      "requires": {
-        "chalk": "~2.1.0",
-        "command-line-args": "^4.0.2",
-        "command-line-commands": "^2.0.0",
-        "command-line-usage": "^4.0.0",
-        "git-config": "0.0.7",
-        "handlebars": "^4.1.0",
-        "inquirer": "^3.0.6",
-        "mkdirp": "^0.5.1",
-        "quickly-copy-file": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.6.1",
-        "semver": "^5.1.0",
-        "toml": "^2.3.0",
-        "ts-typed-json": "^0.2.2",
-        "validate-npm-package-license": "^3.0.1",
-        "validate-npm-package-name": "^3.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "optional": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "optional": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "optional": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
-      }
     },
     "next": {
       "version": "11.1.4",
@@ -11946,86 +8038,6 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
-      }
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-    },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "optional": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "optional": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-          "optional": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.12",
-            "inherits": "2"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "optional": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "node-gyp-build": {
@@ -12204,69 +8216,6 @@
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
-    "node-pre-gyp": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-      "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4.4.2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "optional": true
-        }
-      }
-    },
-    "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
-    },
-    "nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
-    },
-    "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12277,29 +8226,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
     },
-    "npm-bundled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
-      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
-      "requires": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-    },
-    "npm-packlist": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -12308,22 +8234,6 @@
       "requires": {
         "path-key": "^3.0.0"
       }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "number-to-bn": {
       "version": "1.7.0",
@@ -12402,6 +8312,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
       "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -12462,14 +8373,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "requires": {
-        "require-at": "^1.0.6"
-      }
-    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -12489,43 +8392,10 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
-    },
-    "p-defer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-    },
-    "p-fifo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-      "requires": {
-        "fast-fifo": "^1.0.0",
-        "p-defer": "^3.0.0"
-      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -12596,11 +8466,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-duration": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
-      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
-    },
     "parse-headers": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
@@ -12641,7 +8506,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -12676,116 +8542,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peer-id": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.14.8.tgz",
-      "integrity": "sha512-GpuLpob/9FrEFvyZrKKsISEkaBYsON2u0WtiawLHj1ii6ewkoeRiSDFLyIefYhw0jGvQoeoZS05jaT52X7Bvig==",
-      "requires": {
-        "cids": "^1.1.5",
-        "class-is": "^1.1.0",
-        "libp2p-crypto": "^0.19.0",
-        "minimist": "^1.2.5",
-        "multihashes": "^4.0.2",
-        "protobufjs": "^6.10.2",
-        "uint8arrays": "^2.0.5"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "1.1.9",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-          "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "multicodec": "^3.0.1",
-            "multihashes": "^4.0.1",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-          "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1"
-          }
-        },
-        "multicodec": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-          "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-          "requires": {
-            "uint8arrays": "^3.0.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "multihashes": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-          "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-          "requires": {
-            "multibase": "^4.0.1",
-            "uint8arrays": "^3.0.0",
-            "varint": "^5.0.2"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-              "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            },
-            "varint": {
-              "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
-    "pem-jwk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-      "integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-      "requires": {
-        "asn1.js": "^5.0.1"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -12794,17 +8550,13 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pirates": {
       "version": "4.0.1",
@@ -12853,11 +8605,6 @@
         }
       }
     },
-    "precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12873,6 +8620,7 @@
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
       "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "dev": true,
       "requires": {
         "@jest/types": "^27.4.2",
         "ansi-regex": "^5.0.1",
@@ -12883,12 +8631,14 @@
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
         },
         "react-is": {
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
         }
       }
     },
@@ -12896,11 +8646,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
-    },
-    "priorityqueue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/priorityqueue/-/priorityqueue-1.0.0.tgz",
-      "integrity": "sha512-ybkWMIQpEJZ9EIF9yvDZrhc+eqsIA8LQVZ9UybLyT7X5nL9vEgNLZ5Dt/e0EtqEnak8mVsmnjEX1B1TO2M1kyQ=="
     },
     "process": {
       "version": "0.11.10",
@@ -12917,15 +8662,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "promise-to-callback": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
-      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "requires": {
-        "is-fn": "^1.0.0",
-        "set-immediate-shim": "^1.0.1"
-      }
     },
     "prompts": {
       "version": "2.4.2",
@@ -12947,42 +8683,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      }
-    },
-    "protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
-    },
-    "protons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.3.tgz",
-      "integrity": "sha512-j6JikP/H7gNybNinZhAHMN07Vjr1i4lVupg598l4I9gSTjJqOvKnwjzYX2PzvBTSVf2eZ2nWv4vG+mtW8L6tpA==",
-      "requires": {
-        "protocol-buffers-schema": "^3.3.1",
-        "signed-varint": "^2.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.0"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12991,11 +8691,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.8.0",
@@ -13088,26 +8783,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "quickly-copy-file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quickly-copy-file/-/quickly-copy-file-1.0.0.tgz",
-      "integrity": "sha1-n4/wZiMFEO50IrASFHKwk6hpCFk=",
-      "optional": true,
-      "requires": {
-        "mkdirp": "~0.5.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13149,32 +8824,6 @@
             "safer-buffer": ">= 2.1.2 < 3"
           }
         }
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        }
-      }
-    },
-    "rdf-canonize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
-      "requires": {
-        "setimmediate": "^1.0.5"
       }
     },
     "react": {
@@ -13252,27 +8901,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
-    "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-      "optional": true
-    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -13328,11 +8956,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13349,11 +8972,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
       "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
-    },
-    "reset": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
-      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
     },
     "resolve": {
       "version": "1.20.0",
@@ -13400,48 +9018,11 @@
         "lowercase-keys": "^1.0.0"
       }
     },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "optional": true,
-      "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "optional": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "optional": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        }
-      }
-    },
-    "retimer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
-      "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg=="
-    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
-    },
-    "rfc4648": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
-      "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -13469,26 +9050,6 @@
         "bn.js": "^5.2.0"
       }
     },
-    "rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "optional": true
-    },
-    "run": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
-      "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
-      "requires": {
-        "minimatch": "*"
-      }
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "optional": true
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13498,52 +9059,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rustbn.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "optional": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "optional": true,
-      "requires": {
-        "rx-lite": "*"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safe-event-emitter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
-      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
-      "requires": {
-        "events": "^3.0.0"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
     },
     "sax": {
       "version": "1.2.4",
@@ -13582,16 +9106,6 @@
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
-    },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
-    },
-    "semaphore-async-await": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
-      "integrity": "sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo="
     },
     "semver": {
       "version": "6.3.0",
@@ -13647,16 +9161,6 @@
         "request": "^2.79.0",
         "xhr": "^2.3.3"
       }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -13718,15 +9222,8 @@
     "signal-exit": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
-    },
-    "signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
-      "requires": {
-        "varint": "~5.0.0"
-      }
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "dev": true
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -13752,7 +9249,8 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -13791,20 +9289,6 @@
         }
       }
     },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-    },
-    "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -13826,112 +9310,11 @@
         }
       }
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
-    "sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-      "optional": true,
-      "requires": {
-        "memory-pager": "^1.0.2"
-      }
-    },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "optional": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "optional": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "optional": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
-      "optional": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sqlite3": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
-      "integrity": "sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==",
-      "requires": {
-        "node-addon-api": "^3.0.0",
-        "node-gyp": "3.x",
-        "node-pre-gyp": "^0.11.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "node-addon-api": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-        },
-        "node-pre-gyp": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-          "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "sshpk": {
       "version": "1.16.1",
@@ -13949,15 +9332,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
       "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -13965,7 +9344,8 @@
         "escape-string-regexp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
         }
       }
     },
@@ -14010,14 +9390,6 @@
         "debug": "2"
       }
     },
-    "stream-to-it": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-      "requires": {
-        "get-iterator": "^1.0.2"
-      }
-    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -14042,6 +9414,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -14052,6 +9425,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -14350,19 +9724,6 @@
         }
       }
     },
-    "table-layout": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
-      "optional": true,
-      "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
-      }
-    },
     "tar": {
       "version": "4.4.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
@@ -14413,27 +9774,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "optional": true,
-      "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "optional": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -14446,33 +9786,10 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "optional": true
-    },
-    "time-span": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-3.1.0.tgz",
-      "integrity": "sha512-iol7ZQkkMAtlveWFZdTmphGho2RZcUrrg8E3U+YfeDCjFil0sPFU4Q+iyi21HDPwY3vieXV2bjAla75uA6WW+w==",
-      "requires": {
-        "convert-hrtime": "^2.0.0"
-      }
-    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
-    "timeout-abort-controller": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
-      "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "retimer": "^2.0.0"
-      }
     },
     "timers-browserify": {
       "version": "2.0.12",
@@ -14486,15 +9803,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "optional": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "tmpl": {
       "version": "1.0.5",
@@ -14530,12 +9838,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "toml": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
-      "optional": true
-    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -14554,23 +9856,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
-    },
-    "ts-typed-json": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ts-typed-json/-/ts-typed-json-0.2.2.tgz",
-      "integrity": "sha1-UxhL7ok+RZkbc8jEY6OLWeJ81H4=",
-      "optional": true,
-      "requires": {
-        "rsvp": "^3.5.0"
-      },
-      "dependencies": {
-        "rsvp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-          "optional": true
-        }
-      }
     },
     "tsconfig-paths": {
       "version": "3.12.0",
@@ -14629,11 +9914,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
-    "tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
-    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -14651,7 +9931,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.7.1",
@@ -14680,26 +9961,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
       "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
-    },
-    "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-      "optional": true
-    },
-    "uglify-js": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-      "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
-      "optional": true
-    },
-    "uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-      "requires": {
-        "multiformats": "^9.4.2"
-      }
     },
     "ultron": {
       "version": "1.1.1",
@@ -14773,15 +10034,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-    },
-    "ursa-optional": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
-      "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.2"
-      }
     },
     "use-subscription": {
       "version": "1.5.1",
@@ -14857,25 +10109,6 @@
         }
       }
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "optional": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "optional": true,
-      "requires": {
-        "builtins": "^1.0.3"
-      }
-    },
     "varint": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
@@ -14942,15 +10175,6 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
-      }
-    },
-    "web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "requires": {
-        "@zxing/text-encoding": "0.9.0",
-        "util": "^0.12.3"
       }
     },
     "web-streams-polyfill": {
@@ -15204,119 +10428,6 @@
         "web3-utils": "1.6.1"
       }
     },
-    "web3-provider-engine": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-16.0.3.tgz",
-      "integrity": "sha512-Q3bKhGqLfMTdLvkd4TtkGYJHcoVQ82D1l8jTIwwuJp/sAp7VHnRYb9YJ14SW/69VMWoOhSpPLZV2tWb9V0WJoA==",
-      "requires": {
-        "@ethereumjs/tx": "^3.3.0",
-        "async": "^2.5.0",
-        "backoff": "^2.5.0",
-        "clone": "^2.0.0",
-        "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^4.4.2",
-        "eth-json-rpc-filters": "^4.2.1",
-        "eth-json-rpc-infura": "^5.1.0",
-        "eth-json-rpc-middleware": "^6.0.0",
-        "eth-rpc-errors": "^3.0.0",
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-block": "^1.2.2",
-        "ethereumjs-util": "^5.1.5",
-        "ethereumjs-vm": "^2.3.4",
-        "json-stable-stringify": "^1.0.1",
-        "promise-to-callback": "^1.0.0",
-        "readable-stream": "^2.2.9",
-        "request": "^2.85.0",
-        "semaphore": "^1.0.3",
-        "ws": "^5.1.1",
-        "xhr": "^2.2.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "eth-sig-util": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-          "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
-          "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-            "ethereumjs-util": "^5.1.1"
-          }
-        },
-        "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-              "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.3"
-              }
-            }
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "ws": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-          "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
     "web3-providers-http": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.6.1.tgz",
@@ -15427,11 +10538,6 @@
         }
       }
     },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -15481,35 +10587,11 @@
         "is-typed-array": "^1.1.7"
       }
     },
-    "wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "optional": true
-    },
-    "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-      "optional": true,
-      "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
-      }
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -15642,11 +10724,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15693,11 +10770,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
-    },
-    "yieldable-json": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/yieldable-json/-/yieldable-json-2.0.1.tgz",
-      "integrity": "sha512-kFDzXrWlXXt21MQPCul6gAMwwiLoz6XgCbQF+2qNChqdiZnc1SW3l/b/x/XzlZchG2iaVjDIDW5Fnz+sL+FbCw=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/packages/dashboard/pages/create.tsx
+++ b/packages/dashboard/pages/create.tsx
@@ -46,9 +46,21 @@ const Resolver: NextPage<any> = ({
       (content: any) => content.type === 'Mnemonic'
     ).value;
     const keyType = 'secp256k1';
-    const key0 = await wallet.toKeyPair(mnemonic.value, 0, keyType);
-    const key1 = await wallet.toKeyPair(mnemonic.value, 1, keyType);
-    const key2 = await wallet.toKeyPair(mnemonic.value, 2, keyType);
+    const key0 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/1'/0'/0/0"
+    );
+    const key1 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/1'/0'/0/1"
+    );
+    const key2 = await wallet.toKeyPair(
+      mnemonic.value,
+      keyType,
+      "m/44'/1'/0'/0/2"
+    );
     const document: any = {
       publicKeys: [
         {

--- a/packages/did-method-element/src/__test__/wallet/wallet.spec.ts
+++ b/packages/did-method-element/src/__test__/wallet/wallet.spec.ts
@@ -34,9 +34,9 @@ describe('CRUD', () => {
     it('can generate long form did', async () => {
       const mnemonic = vectors.wallet.operations[0].mnemonic;
       const keyType = 'secp256k1';
-      const key0 = await wallet.toKeyPair(mnemonic, 0, keyType);
-      const key1 = await wallet.toKeyPair(mnemonic, 1, keyType);
-      const key2 = await wallet.toKeyPair(mnemonic, 2, keyType);
+      const key0 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/0");
+      const key1 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+      const key2 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/2");
       const document: any = {
         publicKeys: [
           {

--- a/packages/did-method-photon/src/test/wallet.test.ts
+++ b/packages/did-method-photon/src/test/wallet.test.ts
@@ -32,9 +32,9 @@ describe('CRUD', () => {
     it('can generate long form did', async () => {
       const mnemonic = vectors.wallet.operations[0].mnemonic;
       const keyType = 'secp256k1';
-      const key0 = await wallet.toKeyPair(mnemonic, 0, keyType);
-      const key1 = await wallet.toKeyPair(mnemonic, 1, keyType);
-      const key2 = await wallet.toKeyPair(mnemonic, 2, keyType);
+      const key0 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/0");
+      const key1 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+      const key2 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/2");
       const document: any = {
         publicKeys: [
           {

--- a/packages/did-method/src/__tests__/wallet.sanity.test.ts
+++ b/packages/did-method/src/__tests__/wallet.sanity.test.ts
@@ -19,8 +19,8 @@ describe('wallet', () => {
     const { mnemonic, op0 } = vectors.wallet.operations[0];
     const { delta } = op0;
 
-    const key1 = await wallet.toKeyPair(mnemonic, 1, keyType);
-    const key2 = await wallet.toKeyPair(mnemonic, 2, keyType);
+    const key1 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+    const key2 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/2");
     const longFormDid = await wallet.createLongFormDid({
       method: methodName,
       network: methodNetwork,
@@ -40,8 +40,8 @@ describe('wallet', () => {
   });
   it('update operation and resolve updated document', async () => {
     const { mnemonic, op1 } = vectors.wallet.operations[0];
-    const key1 = await wallet.toKeyPair(mnemonic, 1, keyType);
-    const key4 = await wallet.toKeyPair(mnemonic, 4, keyType);
+    const key1 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+    const key4 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/4");
     fixture['update'] = {
       operation: op1,
       updateKey: removeExtraneousProperties(key4),
@@ -53,8 +53,8 @@ describe('wallet', () => {
   });
   it('recover operation and resolve recovered document', async () => {
     const { mnemonic, op2 } = vectors.wallet.operations[0];
-    const key5 = await wallet.toKeyPair(mnemonic, 5, keyType);
-    const key6 = await wallet.toKeyPair(mnemonic, 6, keyType);
+    const key5 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/5");
+    const key6 = await wallet.toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/6");
     fixture['recover'] = {
       operation: op2,
       updateKey: removeExtraneousProperties(key6),

--- a/packages/wallet/src/__test__/generate-ed25519-operation-fixture.test.ts
+++ b/packages/wallet/src/__test__/generate-ed25519-operation-fixture.test.ts
@@ -31,9 +31,9 @@ it('can generate test fixture', async () => {
   for (let i = 0; i < wallet.mnemonic.length; i++) {
     const { mnemonic } = wallet.mnemonic[i];
     // IonRequest module only supports this key type.
-    const key0 = await toKeyPair(mnemonic, 0, keyType);
-    const key1 = await toKeyPair(mnemonic, 1, keyType);
-    const key2 = await toKeyPair(mnemonic, 2, keyType);
+    const key0 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/0");
+    const key1 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+    const key2 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/2");
     const document: SidetreeDocumentModel = {
       publicKeys: [
         {
@@ -59,8 +59,8 @@ it('can generate test fixture', async () => {
 
     const didUniqueSuffix = computeDidUniqueSuffix(op0.suffixData);
 
-    const key3 = await toKeyPair(mnemonic, 3, keyType);
-    const key4 = await toKeyPair(mnemonic, 4, keyType);
+    const key3 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/3");
+    const key4 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/4");
     const input2 = {
       didSuffix: didUniqueSuffix,
       updatePublicKey: key2.publicKeyJwk,
@@ -87,9 +87,9 @@ it('can generate test fixture', async () => {
 
     const op1 = await operations.update(input2);
 
-    const key5 = await toKeyPair(mnemonic, 5, keyType);
-    const key6 = await toKeyPair(mnemonic, 6, keyType);
-    const key7 = await toKeyPair(mnemonic, 7, keyType);
+    const key5 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/5");
+    const key6 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/6");
+    const key7 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/7");
 
     const recoverDocument: SidetreeDocumentModel = {
       publicKeys: [

--- a/packages/wallet/src/__test__/generate-keypair-fixture.test.ts
+++ b/packages/wallet/src/__test__/generate-keypair-fixture.test.ts
@@ -25,9 +25,9 @@ it('can generate test fixture', async () => {
 
   for (let i = 0; i < wallet.mnemonic.length; i++) {
     const { mnemonic } = wallet.mnemonic[i];
-    const kp0 = await toKeyPair(mnemonic, 0, 'Ed25519');
-    const kp1 = await toKeyPair(mnemonic, 0, 'X25519');
-    const kp2 = await toKeyPair(mnemonic, 0, 'secp256k1');
+    const kp0 = await toKeyPair(mnemonic, 'Ed25519', "m/44'/1'/0'/0/0");
+    const kp1 = await toKeyPair(mnemonic, 'X25519', "m/44'/1'/0'/0/0");
+    const kp2 = await toKeyPair(mnemonic, 'secp256k1', "m/44'/1'/0'/0/0");
     fixture.keypair.push({
       mnemonic,
       Ed25519: kp0,

--- a/packages/wallet/src/__test__/generate-secp256k1-operation-fixture.test.ts
+++ b/packages/wallet/src/__test__/generate-secp256k1-operation-fixture.test.ts
@@ -31,9 +31,9 @@ it('can generate test fixture', async () => {
   for (let i = 0; i < wallet.mnemonic.length; i++) {
     const { mnemonic } = wallet.mnemonic[i];
     // IonRequest module only supports this key type.
-    const key0 = await toKeyPair(mnemonic, 0, keyType);
-    const key1 = await toKeyPair(mnemonic, 1, keyType);
-    const key2 = await toKeyPair(mnemonic, 2, keyType);
+    const key0 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/0");
+    const key1 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/1");
+    const key2 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/2");
     const document: SidetreeDocumentModel = {
       publicKeys: [
         {
@@ -59,8 +59,8 @@ it('can generate test fixture', async () => {
 
     const didUniqueSuffix = computeDidUniqueSuffix(op0.suffixData);
 
-    const key3 = await toKeyPair(mnemonic, 3, keyType);
-    const key4 = await toKeyPair(mnemonic, 4, keyType);
+    const key3 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/3");
+    const key4 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/4");
     const input2 = {
       didSuffix: didUniqueSuffix,
       updatePublicKey: key2.publicKeyJwk,
@@ -87,9 +87,9 @@ it('can generate test fixture', async () => {
 
     const op1 = await operations.update(input2);
 
-    const key5 = await toKeyPair(mnemonic, 5, keyType);
-    const key6 = await toKeyPair(mnemonic, 6, keyType);
-    const key7 = await toKeyPair(mnemonic, 7, keyType);
+    const key5 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/5");
+    const key6 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/6");
+    const key7 = await toKeyPair(mnemonic, keyType, "m/44'/1'/0'/0/7");
 
     const recoverDocument: SidetreeDocumentModel = {
       publicKeys: [

--- a/packages/wallet/src/operations/toKeyPair.test.ts
+++ b/packages/wallet/src/operations/toKeyPair.test.ts
@@ -16,16 +16,28 @@ import { toKeyPair } from './toKeyPair';
 import { wallet } from '@sidetree/test-vectors';
 
 it('can generate key pair Ed25519', async () => {
-  const content = await toKeyPair(wallet.keypair[0].mnemonic, 0, 'Ed25519');
+  const content = await toKeyPair(
+    wallet.keypair[0].mnemonic,
+    'Ed25519',
+    "m/44'/1'/0'/0/0"
+  );
   expect(content).toEqual(wallet.keypair[0].Ed25519);
 });
 
 it('can generate key pair X25519', async () => {
-  const content = await toKeyPair(wallet.keypair[0].mnemonic, 0, 'X25519');
+  const content = await toKeyPair(
+    wallet.keypair[0].mnemonic,
+    'X25519',
+    "m/44'/1'/0'/0/0"
+  );
   expect(content).toEqual(wallet.keypair[0].X25519);
 });
 
 it('can generate key pair secp256k1', async () => {
-  const content = await toKeyPair(wallet.keypair[0].mnemonic, 0, 'secp256k1');
+  const content = await toKeyPair(
+    wallet.keypair[0].mnemonic,
+    'secp256k1',
+    "m/44'/1'/0'/0/0"
+  );
   expect(content).toEqual(wallet.keypair[0].secp256k1);
 });

--- a/packages/wallet/src/operations/toKeyPair.ts
+++ b/packages/wallet/src/operations/toKeyPair.ts
@@ -17,15 +17,9 @@ import { UNIVERSAL_WALLET_CONTEXT_URL, placeHolderImage } from '../constants';
 export const toKeyPair = async (
   mnemonic: string,
   type = 'Ed25519',
-  hdPath: string,
-  index = -1
+  hdPath: string
 ): Promise<any> => {
-  const keypair: any = await sidetreeCrypto.toKeyPair(
-    mnemonic,
-    type,
-    hdPath,
-    index
-  );
+  const keypair: any = await sidetreeCrypto.toKeyPair(mnemonic, type, hdPath);
   const jsonWebKeyPair = await keypair.export({
     type: 'JsonWebKey2020',
     privateKey: true,

--- a/packages/wallet/src/operations/toKeyPair.ts
+++ b/packages/wallet/src/operations/toKeyPair.ts
@@ -16,15 +16,15 @@ import { UNIVERSAL_WALLET_CONTEXT_URL, placeHolderImage } from '../constants';
 
 export const toKeyPair = async (
   mnemonic: string,
-  index: number,
   type = 'Ed25519',
-  hdPath?: string
+  hdPath: string,
+  index = -1
 ): Promise<any> => {
   const keypair: any = await sidetreeCrypto.toKeyPair(
     mnemonic,
-    index,
     type,
-    hdPath
+    hdPath,
+    index
   );
   const jsonWebKeyPair = await keypair.export({
     type: 'JsonWebKey2020',

--- a/packages/wallet/src/pluginFactory.ts
+++ b/packages/wallet/src/pluginFactory.ts
@@ -32,8 +32,7 @@ interface SidetreePlugin {
   toKeyPair: (
     mnemonic: string,
     type: string,
-    hdPath: string,
-    index?: number
+    hdPath: string
   ) => Promise<KeyPair>;
   operations: any;
   createLongFormDid: (input: {

--- a/packages/wallet/src/pluginFactory.ts
+++ b/packages/wallet/src/pluginFactory.ts
@@ -33,7 +33,7 @@ interface SidetreePlugin {
     mnemonic: string,
     type: string,
     hdPath: string,
-    index: number
+    index?: number
   ) => Promise<KeyPair>;
   operations: any;
   createLongFormDid: (input: {

--- a/packages/wallet/src/pluginFactory.ts
+++ b/packages/wallet/src/pluginFactory.ts
@@ -32,7 +32,8 @@ interface SidetreePlugin {
   toKeyPair: (
     mnemonic: string,
     index: number,
-    type?: string
+    type: string,
+    hdPath?: string
   ) => Promise<KeyPair>;
   operations: any;
   createLongFormDid: (input: {

--- a/packages/wallet/src/pluginFactory.ts
+++ b/packages/wallet/src/pluginFactory.ts
@@ -31,9 +31,8 @@ interface SidetreePlugin {
   toMnemonic: (mnemonic?: string) => Promise<Mnemonic>;
   toKeyPair: (
     mnemonic: string,
-    index: number,
     type: string,
-    hdPath?: string
+    hdPath: string
   ) => Promise<KeyPair>;
   operations: any;
   createLongFormDid: (input: {

--- a/packages/wallet/src/pluginFactory.ts
+++ b/packages/wallet/src/pluginFactory.ts
@@ -32,7 +32,8 @@ interface SidetreePlugin {
   toKeyPair: (
     mnemonic: string,
     type: string,
-    hdPath: string
+    hdPath: string,
+    index: number
   ) => Promise<KeyPair>;
   operations: any;
   createLongFormDid: (input: {


### PR DESCRIPTION
This PR updates the `dashboardWalletFactory.toKeyPair()` method to allow the HD path parameter. This PR also adds a sanity check test to make sure that the `dashboardWalletFactory.toKeyPair()` and the `@sidetree.wallet's toKeyPair()` operations generate the exact same keys as https://api.did.actor/ when using the same input.



