### PR TITLE
Update Dashboard and Photon Readme

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -62,10 +62,12 @@ conditions.
 
 ### DID Ion
 
+[DID Ion Spec](https://github.com/decentralized-identity/ion)  
 See https://github.com/transmute-industries/sidetree.js/issues/379
 
 ### DID Orb
 
+[DID Orb Spec](https://github.com/trustbloc/orb)  
 See https://github.com/transmute-industries/sidetree.js/issues/380
 
 ## What You Can Do In The App

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,7 +1,22 @@
 # @sidetree/dashboard
 
-This package contains a Next.js app that can be used to operate a sidetree node.
+1. Summary
+   - Docker Hub Image
+3. Setting up a Node
+   - DID Element
+   - DID Photon
+   - DID Ion
+   - DID Orb
+4. What You Can Do In The App
+   - Create a Wallet
+   - Creaye a DID
+   - Viewing Node Transactions
+   - Viewing Node Operations
+   - Resolving a DID
 
+## Summary
+
+This package contains a Next.js app that can be used to operate a sidetree node.
 Running this application will start up a sidetree node and provide you a simple UI to interact with the node.
 
 This UI will allow you to:
@@ -12,91 +27,50 @@ This UI will allow you to:
 - See the transactions that are happening on your node.
 - See the operations that are happening on your node.
 
-As it stands now, the following operations are not available:
+The following operations are not available from the UI:
 
 - Delete DID
 - Update DID
 
-Deployed node of Element Ropsten Testnet: [ropsten.element.transmute.industries](https://ropsten.element.transmute.industries)
+### Docker Hub Image
 
 Docker hub image: https://hub.docker.com/r/transmute/sidetree-dashboard
 
-## Running Your Sidetree Node
+## Setting Up a Node
 
-[GCP](docs/deploy-to-gcp.md)
+The Sidetree Dashboard is intended to be a general purpose implementation of the Sidetree protocol.
+Environment variables are required for setting up a Node with a specific Ledger/CAS combination.
 
-## Cloning the Repo & Setting Up The Project
+### DID Element
 
-First you will need to begin by cloning the Sidetree.js repo if you have not done so already. Next you will need to navigate to the dashboard directorty.
+[DID Element Spec](https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method-element)  
+Deployed node of Element Ropsten Testnet: [ropsten.element.transmute.industries](https://ropsten.element.transmute.industries)
 
-You can do this with the following command:
+DID Element uses the Etherum Ledger and IPFS for Content Addressable Storage. 
+DID Element uses Ganache locally for a developer environment, and Ropsten for a test envrionment.
+Below are several readme's which describe how to set up an Element Node covering different possible deployment
+conditions. 
 
-```
-git clone git@github.com:transmute-industries/sidetree.js.git
-cd sidetree.js
-npm install
-```
+- [Setup a Development Node with Ganache on a Raspberry Pi](https://github.com/transmute-industries/sidetree.js/blob/main/packages/did-method-element/docs/local-dev.md)
+- [Setup a Testnet Node with Ropsten on a Raspberry Pi](https://github.com/transmute-industries/sidetree.js/blob/main/packages/did-method-element/docs/local-element-ropsten-install.md)
+- [Setup a Testnet Node with Ropsten using Docker](https://github.com/transmute-industries/sidetree.js/blob/main/packages/did-method-element/docs/docker-element-ropsten-install.md)
+- [Setup a Testnet Node with Google Cloud Platform](https://github.com/transmute-industries/sidetree.js/blob/main/packages/dashboard/docs/deploy-to-gcp.md)
 
-Important: The `lerna bootstrap` command will build all of the packages and link them so everything works properly.
+### DID Photon
 
-## Running Your Sidetree Node
+[DID Photon Spec](https://github.com/transmute-industries/sidetree.js/tree/main/packages/did-method-photon)
 
-Before you run your sidetree node, we need to make sure we have all of our environment variables properly configured for the type of node we will be running.
+### DID Ion
 
-There are currently 3 DID method configurations you can use to run your node. They are:
+See https://github.com/transmute-industries/sidetree.js/issues/379
 
-1. example:sidetree.testnet
-2. elem:ganache
-3. elem:ropsten
+### DID Orb
 
-Inside this package is an example env file for each configuration along with instructions on how to set up that type of node below.
+See https://github.com/transmute-industries/sidetree.js/issues/380
 
-### Running an `example:sidetree.testnet` node
+## What You Can Do In The App
 
-This is a mock ledger. This means this configuration should work locally even if you are not connected to the internet.
-
-If you are going to use this configuration, you will need to use all of the environment variables found in the `.env.testnet.example` file.
-
-So before doing anything you will need to copy the contents of `.env.example:sidetree.testnet.example` to a new `.env.example:sidetree.testnet` file at the root of the `packages/dashboard` directory.
-
-Once you have you env file set up you can start the node 2 ways:
-
-1. Using Docker: `npm run dev:docker`. This will set up the node inside a docker container. This will server the dashboard at `http://localhost:8080`.
-2. `npm run dev`. This will server the dashboard at `http://localhost:3000`.
-
-### Running an `elem:ganache` node
-
-This is a single node that simulates a real blockchain. This means this configuration should work locally even if you are not connected to the internet.
-
-If you are going to use this configuration, you will need to use all of the environment variables found in the `.env.ganache.example` file.
-
-So before doing anything you will need to copy the contents of `.env.ganache.example` to a new `.env.ganache` file at the root of the `packages/dashboard` directory.
-
-Once you have your env file set up, you will need do download Ganache if you have not already. You can download this here: https://trufflesuite.com/ganache/.
-
-After you have the program installed, you will need to open up the application and modify the server settings to use the port specified inside your `.env.ganache` file.
-
-Once you have you env file and Ganache set up you can start the node 2 ways:
-
-1. Using Docker: `npm run dev:ganache:docker`. This will set up the node inside a docker container. This will server the dashboard at `http://localhost:8080`.
-2. `npm run dev:ganache`. This will server the dashboard at `http://localhost:3000`.
-
-### Running an `elem:ropsten` node
-
-This is a testnet.
-
-If you are going to use this configuration, you will need to use all of the environment variables found in the `.env.ropsten.example` file.
-
-So before doing anything you will need to copy the contents of `.env.ropsten.example` to a new `.env.ropsten` file at the root of the `packages/dashboard` directory.
-
-WARNING: You need to make sure your ENV file is never committed to source control. Specifically because it uses your mnemonic phrase.
-
-Once you have you env file set up you can start the node 2 ways:
-
-1. Using Docker: `npm run dev:ropsten:docker`. This will set up the node inside a docker container. This will server the dashboard at `http://localhost:8080`.
-2. `npm run dev:ropsten`. This will server the dashboard at `http://localhost:3000`.
-
-### What You Can Do In The App
+![Sidetree.js Dashboard](https://user-images.githubusercontent.com/25621780/159126440-f872454c-fd31-49ac-957e-99eab1c62fd2.png)
 
 When the application first loads, you should be greeted with a welcome screen listing the did method you are using in the node.
 
@@ -108,6 +82,8 @@ The different sections of the application are:
 
 #### Create a wallet (Manage)
 
+![Sidetree.js Create Wallet](https://user-images.githubusercontent.com/25621780/159128369-336a4dc3-ed3f-4ae4-a7df-f348340d177e.png)
+
 Before you can create a DID, you will need to create a wallet. This can be done by clicking the "Manage CTA". This should take you to the `http://localhost:3000/wallet` page.
 
 If you do not already have a wallet, you should see a prompt asking you to generate one. To generate a wallet, simply click the button in the prompt.
@@ -115,6 +91,8 @@ If you do not already have a wallet, you should see a prompt asking you to gener
 One your wallet is created, the conents of the wallet are kept in the browsers `localStorage`. This means you will need to access this to obtain any DIDs you create or add to the wallet.
 
 #### Creating a DID (Manage)
+
+![Sidetree.js Create DID](https://user-images.githubusercontent.com/25621780/159128394-ee5f655c-cf08-4e34-a535-0a88e2592140.png)
 
 Now that we have a wallet created, we will be able to create a DID.
 
@@ -132,7 +110,7 @@ Now that we have created a DID using our node, we should be able to see this tra
 
 If you click the `Transactions` menu in the application sidebar, you should be taking to `http://localhost:3000/transactions` where you will see a table and 1 transaction listed.
 
-#### Viwing Node Operations (Explore)
+#### Viewing Node Operations (Explore)
 
 You can also view the latest operations performed by the node by clicking the `Operations` menu item in the application sidebar.
 

--- a/packages/did-method-photon/README.md
+++ b/packages/did-method-photon/README.md
@@ -1,14 +1,72 @@
 # @sidetree/photon
 
-This package contains an implementation of Sidetree Core, using AWS QLDB and IPFS
+![Transmute Photon Logo](./photon-logo.png)
 
-## Usage
+1. About Photon
+   - Performance
+   - DID Photon FIPS Compliance
+   - QLDB
+3. Package Information
+   - Development
+   - Photon Package
+5. Photon DID Method Spec
+   - Abstract
+   - Method Syntax
+   - CRUD Operations
+   - Resolve Operation
+
+## About Photon
+
+Photon is meant for production application, that require speed, scalability, reliability and security.
+
+As opposed to most public permissionless ledgers, AWS QLDB is centralized and fully managed. At the cost of having Amazon as a root of trust, hence not being decentralized, QLDB gets significant speed, reliability and scalability benefits, while retaining all the cryptographic properties like immutability that an append only ledger provides.
+
+These properties of AWS QLDB combined with the use of [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2) compliant cryptography make Photon more suitable for government use cases than DID method based on public ledgers like Bitcoin and Ethereum which are powered by the not (yet) NIST approved secp256k1 elliptic curve.
+
+### Performance
+
+See [Issue #118: Add scalability notes to ledger-qldb](https://github.com/transmute-industries/sidetree.js/issues/118)  
+TODO: Benchmark comparing the capacity (measured in anchored DIDs per second) of several Sidetree based DID methods:
+
+- Element
+- Ion
+- Photon
+
+### DID Photon FIPS Compliance
+
+Regarding FIPS Compliance, we have the following recommendations:
+
+Use [AWS KMS](https://aws.amazon.com/kms/) for keys:
+
+"AWS KMS is a secure and resilient service that uses hardware security modules that have been validated under FIPS 140-2, or are in the process of being validated, to protect your keys."
+
+Use an official FIPS compliant signature algorithm like ES256 ES384.
+
+EdDSA with Ed25519 is [still in draft phase](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5-draft.pdf).
+
+Possible to run core compomnents in [GovCloud](https://aws.amazon.com/govcloud-us):
+
+- IPFS node in EC2
+- DynamoDB cache
+- KMS
+
+
+### QLDB
+
+- Contrary to public ledgers, write access to QLDB requires [IAM credentials](https://aws.amazon.com/iam/), hence only authorized actors can create and update DIDs
+- The [security of the QLDB ledger](https://docs.aws.amazon.com/qldb/latest/developerguide/security.html) relies on the [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) which means
+  - AWS is responsible for operating, managing and controlling the components from the host operating system and virtualization layer down to the physical security of the facilities in which the service operates.
+  - We are responsible for security of keys associated with the IAM credentials
+- QLDB uses a Merkle Tree with the SHA256 hash function to build its immutable ledger capabilities, which is part of FIPS's Secure Hash Standard. See https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+- "[Data in transit is encrypted using TLS](https://docs.aws.amazon.com/qldb/latest/developerguide/data-protection.html)"
+
+## Package Information
 
 ```
 npm install --save @sidetree/photon
 ```
 
-## Development
+### Development
 
 ```
 npm install
@@ -29,106 +87,241 @@ To test photon specificly run
 npm run test:only @sidetree/photon
 ```
 
-# Photon DID Method Spec
+## Photon DID Method Spec
 
-<p align="center">
-  <img width="300" height="300" src="./photon-logo.png">
-</p>
+### Abstract
 
-## Abstract
-
-Photon is an implementation of [version v0.1.0 of the Sidetree protocol](https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/). It uses
+Photon is an implementation of [version v1.0.0 of the Sidetree protocol](https://identity.foundation/sidetree/spec/). It uses
 
 - [Amazon QLDB](https://aws.amazon.com/qldb/) for the ledger layer, a fully managed ledger database that provides a transparent, immutable, and cryptographically verifiable transaction log ‎owned by a central trusted authority. Amazon QLDB can be used to track each and every application data change and maintains a complete and verifiable history of changes over time.
-- [IPFS](https://ipfs.io/) for the Content-addressable storage layer
+- [Amazon S3](https://aws.amazon.com/s3/) for the Content-addressable storage layer
 
-For more information about Sidetree, see:
-
-- https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/
-- github.com/transmute-industries/sidetree.js
-- https://github.com/decentralized-identity/sidetree
-
-## Introduction
-
-Photon is meant for production application, that require speed, scalability, reliability and security.
-
-As opposed to most public permissionless ledgers, AWS QLDB is centralized and fully managed. At the cost of having Amazon as a root of trust, hence not being decentralized, QLDB gets significant speed, reliability and scalability benefits, while retaining all the cryptographic properties like immutability that an append only ledger provides.
-
-These properties of AWS QLDB combined with the use of [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2) compliant cryptography make Photon more suitable for government use cases than DID method based on public ledgers like Bitcoin and Ethereum which are powered by the not (yet) NIST approved secp256k1 elliptic curve.
-
-## Performance
-
-TODO: Benchmark comparing the capacity (measured in anchored DIDs per second) of several Sidetree based DID methods:
-
-- Element
-- Ion
-- Photon
-
-## Method syntax
+### Method syntax
 
 The namestring identifying this did method is `photon`
 
 A DID that uses this method MUST begin with the following prefix: `did:photon`. Per the DID specification, this string MUST be in lowercase.
 
-The remainder of a DID after the prefix, called the did unique suffix, MUST be `SHA256` hash of the encoded create payload. See https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#did-uri-composition for more information.
+The remainder of a DID after the prefix, called the did unique suffix, MUST be `SHA256` hash of the encoded create payload. See the [DID Uri Spec](https://identity.foundation/sidetree/spec/#did-uri-composition) for more information.
 
 An example of a valid photon did is: `did:photon:EiDjQYg7Q2pwgj4BQCEnq7yZrY9YEWbg6toqbQQPPW6jaA`
 
-## CRUD Operations
+### CRUD Operations
 
-Photon supports the CRUD operations;
+Photon supports the 4 CRUD operations defined in the [Sidetree Protocol API Specification](https://identity.foundation/sidetree/api/).
+Each operation is performed by submitting a Sidetree operation in the form of and HTTP POST request to a Sidetree node.
+The body of the HTTP POST request for an operation will have the Content-Type of `application/json` to the `[server path]/operations` REST end point.
 
-### Create
+```
+{
+  "type": OPERATION_TYPE,
+  ...
+}
+```
 
-https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#create
+The only required field of the JSON HTTP POST data is the operation type, which can be `create`, `update`, `recover` or `deactivate`.
+The other fields are operation specific, and defined in the sections below. Example code for generating each one of these operations
+for Photon can be found in the [wallet test](https://github.com/transmute-industries/sidetree.js/blob/main/packages/did-method/src/__tests__/wallet.sanity.test.ts).
 
-### Read / Resolve
+#### Create Operation
 
-https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#resolution
+Example Create
 
-### Update
+```json
+{
+  "type":"create",
+  "suffixData":{
+    "deltaHash":"EiCP8MJ9oX2jmTxVi6xa1WoGmzkg8HaxmWWiR6R34cUmvw",
+    "recoveryCommitment":"EiCFei9R_74JeKbxGIZPI4XXwbb0eDpBeweA9IpymBEOFA"
+  },
+  "delta":{
+    "updateCommitment":"EiDDJ-s9CPjkh6yaH5apLIKZ1G87K0phukB3Fofy2ujeAg",
+    "patches":[
+      {
+        "action":"replace",
+        "document":{
+          "publicKeys":[
+            {
+              "id":"signingKey",
+              "type":"EcdsaSecp256k1VerificationKey2019",
+              "publicKeyJwk":{
+                "kty":"EC",
+                "crv":"secp256k1",
+                "x":"8a7JVJUDcR_mS6gyTAgdvGFZkhO8plwWfId3xqHa7xA",
+                "y":"xIxXstl9XR-hXXBkrhzxrFhJRvab2MLhQDus92S8G2o"
+              },
+              "purposes":[
+                "authentication",
+                "assertionMethod",
+                "capabilityInvocation",
+                "capabilityDelegation",
+                "keyAgreement"
+              ]
+            }
+          ],
+          "services":[
+            {
+              "id":"serviceId123",
+              "type":"someType",
+              "serviceEndpoint":"https://www.url.com"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
 
-https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#update
+#### Recover
 
-For update operations, Photon only supports `ietf-json-patch`, see https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#did-state-patches
+Example Recover
 
-### Recover
+```json
+{
+  "type":"recover",
+  "didSuffix":"EiB_4F3m_qz5tBdRmC7tcMOQJxvKSyICzQ4Uxt8cGTN5Vg",
+  "revealValue":"EiBDFxzWmxgVG9SH-PY-9Yz73-6mnI8egnypTx1fjlKMKw",
+  "signedData":"eyJhbGciOiJFUzI1NksifQ.eyJkZWx0YUhhc2giOiJFaURaeXJBQk13dGZ1YmNGSXlZelhkb09wNXdObzZCNW82MGxvaUg1Qkh3VldRIiwicmVjb3ZlcnlLZXkiOnsia3R5IjoiRUMiLCJjcnYiOiJzZWNwMjU2azEiLCJ4IjoiODZzeDZ5dVdZWjVMRFp1WFd4WF9FdEtrbFN1a21jSDdQZUIzNFNrWUVjZyIsInkiOiJzVlR6VGhVejNDRk82N2doWHVIQXV6Q2ZCVWdKa0V3WkZrbzZQM0ZzNnIwIn0sInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpREFUNGxlYm14S3FTOXFyT1ROZ0lOakJ1aHY1VUJWS1h3Y0NQQ0hiellNX1EifQ.w9jDo4hrTVxbA3oA7QH6YOiTSM5y1f697Dj7m4DPg3ShbhjK3KwXmrHEu5lpFXcxAFB47hW0G1rzm7PpNm9bwQ",
+  "delta":{
+    "patches":[
+      {
+        "action":"replace",
+        "document":{
+            "publicKeys":[
+            {
+              "id":"signingKey",
+              "type":"EcdsaSecp256k1VerificationKey2019",
+              "publicKeyJwk":{
+                "kty":"EC",
+                "crv":"secp256k1",
+                "x":"naoGdqBTAvOAVaXjRJb_MW2BPw86iGWLs4i9ylN0dbE",
+                "y":"dOfZc0yVkTm70h_ixQOu-B_T29dzxGTILf1-xoqYeao"
+              },
+              "purposes":[
+                "authentication",
+                "assertionMethod",
+                "capabilityInvocation",
+                "capabilityDelegation",
+                "keyAgreement"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "updateCommitment":"EiDDJ-s9CPjkh6yaH5apLIKZ1G87K0phukB3Fofy2ujeAg"
+  }
+}
+```
 
-https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#recover
+#### Update
 
-### Deactivate
+Example Update 
 
-https://web.archive.org/web/20200721150053/https://identity.foundation/sidetree/spec/v0.1.0/#deactivate
+```json
+{
+  "type":"update",
+  "didSuffix":"EiBuuicWVxOcbhCW0N9YSRJwB7auqbzhMhKg1qXRTR30_A",
+  "revealValue":"EiD0FtXueh5RDV_DlLcOuxjPnT-pheGPfhvaYUivLpGmZA",
+  "delta":{
+    "patches":[
+      {
+        "action":"add-services",
+        "services":[
+          {
+            "id":"someId",
+            "type":"someType",
+            "serviceEndpoint":"someEndpoint"
+          }
+        ]
+      }
+    ],
+    "updateCommitment":"EiDJa1d1800h2jcvLOJ5eoga5PrIA9WAwxrKGvUYXJwTeQ"
+  },
+  "signedData":"eyJhbGciOiJFUzI1NksifQ.eyJ1cGRhdGVLZXkiOnsia3R5IjoiRUMiLCJjcnYiOiJzZWNwMjU2azEiLCJ4IjoiMTdOVnAwX3pwLUJON3FkeTJhbkNqcDk1TS1sVF9pZ2xpTENEZ1hvS2F6YyIsInkiOiJ4TzJPQlZSOGxFTW94N1hvYzVYU1dYSC1yUm5jbHk5b2NvTVBUVkhVZmtzIn0sImRlbHRhSGFzaCI6IkVpQ2VkUlZYWGRaU0VMSmRqNzhJclVwaFVJYkVSWFA1UWlrSTN1ZEVvSmFRcEEifQ.-oeeFd4XrAf1L9pt0V_MjXIEubqAEHKPGA1s3JnrdWLHcG3uXF2wZSI_xoDMTlRuwHkJjt-tt918Ce9OXwi4PQ"
+}
+```
 
-## Security and privacy considerations
+The list of patches currently supported is:
 
-### QLDB
+- `add-public-keys`
+- `add-authentication`
+- `remove-authentication`
+- `add-assertion-method`
+- `remove-assertion-method`
+- `add-capability-delegation`
+- `remove-capability-delegation`
+- `add-capability-invocation`
+- `remove-capability-invocation`
+- `add-key-agreement`
+- `remove-key-agreement`
+- `add-service-endpoint`
+- `remove-service-endpoint`
 
-- Contrary to public ledgers, write access to QLDB requires [IAM credentials](https://aws.amazon.com/iam/), hence only authorized actors can create and update DIDs
-- The [security of the QLDB ledger](https://docs.aws.amazon.com/qldb/latest/developerguide/security.html) relies on the [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) which means
-  - AWS is responsible for operating, managing and controlling the components from the host operating system and virtualization layer down to the physical security of the facilities in which the service operates.
-  - We are responsible for security of keys associated with the IAM credentials
-- QLDB uses a Merkle Tree with the SHA256 hash function to build its immutable ledger capabilities, which is part of FIPS's Secure Hash Standard. See https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-- "[Data in transit is encrypted using TLS](https://docs.aws.amazon.com/qldb/latest/developerguide/data-protection.html)"
 
-### IPFS
+#### Deactivate
 
-- With Sidetree, data integrity is guaranteed with the use of [Content-addressable storage](https://docs.ipfs.io/concepts/content-addressing/#identifier-formats). IPFS is a popular CAS solution to store immutable objects. An immutable object is an object whose state cannot be altered or modified once created. Once a file is added to the IPFS network, the content of that file cannot be changed without altering the content identifier (CID) of the file.
+Example Deactivate.
 
-### DID Photon FIPS Compliance
+```json
+{
+  "type":"deactivate",
+  "didSuffix":"EiBuuicWVxOcbhCW0N9YSRJwB7auqbzhMhKg1qXRTR30_A",
+  "revealValue":"EiCk-d_6aijSJVJ9K00qlfprLUew_TUZqZ4b8dtl_5mpww",
+  "signedData":"eyJhbGciOiJFUzI1NksifQ.eyJkaWRTdWZmaXgiOiJFaUJ1dWljV1Z4T2NiaENXME45WVNSSndCN2F1cWJ6aE1oS2cxcVhSVFIzMF9BIiwicmVjb3ZlcnlLZXkiOnsia3R5IjoiRUMiLCJjcnYiOiJzZWNwMjU2azEiLCJ4IjoiLUhWWFJRNVNGTnRoWFk2Mkxya3N2Z2dqdkVlaEF1Sll3bTVkS0ZZSzJ5ZyIsInkiOiJqQVVqYmo5N3I2dDNTY0pvVW1DTjRwejRpdXVpdGVrMEtKSlFaMndHU1g4In19.L9fl_GHr5jseHUckE0dx4ib-YkFiFBx5YgdFJ8_pcNa71JPTbGT2T4_WY7HUsQqBe_F-yzoDd_FozspFC2PqKw"
+}
+```
 
-Regarding FIPS Compliance, we have the following recommendations:
+### Resolve Operation
 
-Use [AWS KMS](https://aws.amazon.com/kms/) for keys:
+To resolve a DID , send a GET request to the `[server path]/identity/{did}` REST end point.
+For example, to resolve the DID `did:photon:EiCtwD11AV9e1oISQRHnMJsBC3OBdYDmx8xeKeASrKaw6A`, we should get the following response. 
 
-"AWS KMS is a secure and resilient service that uses hardware security modules that have been validated under FIPS 140-2, or are in the process of being validated, to protect your keys."
+```
+{
+  "@context": "https://w3id.org/did-resolution/v1",
+  "didDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/suites/jws-2020/v1",
+      {
+        "@vocab": "https://www.w3.org/ns/did#"
+      }
+    ],
+    "id": "did:photon:EiCtwD11AV9e1oISQRHnMJsBC3OBdYDmx8xeKeASrKaw6A",
+    "verificationMethod": [
+      {
+        "id": "#zQ3shvfXLUVwKffPochZ1UkSjxQqpgND3Z5DhzTADooqmmypp",
+        "controller": "did:photon:EiCtwD11AV9e1oISQRHnMJsBC3OBdYDmx8xeKeASrKaw6A",
+        "type": "JsonWebKey2020",
+        "publicKeyJwk": {
+          "kty": "EC",
+          "crv": "secp256k1",
+          "x": "7hfx9LZXlMBaZ2EurUcXOITSIGLIFQ4YY7pXCbEqntU",
+          "y": "B1FId5MlHAuhxsDU9uvPuE2JXKVPP3ohjuR6HUvY6XM"
+        }
+      }
+    ],
+    "authentication": [
+      "#zQ3shvfXLUVwKffPochZ1UkSjxQqpgND3Z5DhzTADooqmmypp"
+    ],
+    "assertionMethod": [
+      "#zQ3shvfXLUVwKffPochZ1UkSjxQqpgND3Z5DhzTADooqmmypp"
+    ],
+    "keyAgreement": [
+      "#zQ3shvfXLUVwKffPochZ1UkSjxQqpgND3Z5DhzTADooqmmypp"
+    ]
+  },
+  "didDocumentMetadata": {
+    "method": {
+      "published": true,
+      "recoveryCommitment": "EiB2lrE88cmhcepLS-p8wBbxHfZKSvniCKfL0CfZe4i36g",
+      "updateCommitment": "EiBch3E26X_PoJ_Io2NS8-Dn6F94hcMAChZ6-AaZ2B_pUQ"
+    },
+    "canonicalId": "did:photon:EiCtwD11AV9e1oISQRHnMJsBC3OBdYDmx8xeKeASrKaw6A"
+  }
+}
+```
 
-Use an official FIPS compliant signature algorithm like ES256 ES384.
 
-EdDSA with Ed25519 is [still in draft phase](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5-draft.pdf).
-
-Possible to run core compomnents in [GovCloud](https://aws.amazon.com/govcloud-us):
-
-- IPFS node in EC2
-- DynamoDB cache
-- KMS


### PR DESCRIPTION
The current Dashboard document contains confusing explanations on how to set up a DID Element node. Since Dashboard now supports both did:elem and did:photon, I changed the dashboard to list each of the supported did methods and provide links to the readme's for how to create a node. 