### PR TITLE
Improved Logging to See # of New Transaction in GCP logs since last transaction in Mongo

### DIFF
--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -191,6 +191,11 @@ export default class QLDBLedger implements IBlockchain {
       );
     }
     const resultList: unknown[] = (result as Result).getResultList();
+    console.warn(
+      `There has been ${
+        resultList.length - 1
+      } new transactions since transaction #${sinceTransactionNumber}`
+    );
     const transactions: TransactionModelQLDB[] = (resultList as ValueWithMetaData[]).map(
       this.toSidetreeTransaction
     ) as TransactionModelQLDB[];

--- a/packages/ledger-qldb/src/QLDBLedger.ts
+++ b/packages/ledger-qldb/src/QLDBLedger.ts
@@ -192,9 +192,8 @@ export default class QLDBLedger implements IBlockchain {
     }
     const resultList: unknown[] = (result as Result).getResultList();
     console.warn(
-      `There has been ${
-        resultList.length - 1
-      } new transactions since transaction #${sinceTransactionNumber}`
+      `There has been ${resultList.length -
+        1} new transactions since transaction #${sinceTransactionNumber}`
     );
     const transactions: TransactionModelQLDB[] = (resultList as ValueWithMetaData[]).map(
       this.toSidetreeTransaction


### PR DESCRIPTION
Small PR to add some additional logging so we can see the # of transactions that have occurred since our last saved one in MongoDB when looking at the GCP logs.