### PR TITLE
docs: remove inactive node from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The following did methods are supported or intended to be supported (or planned 
 **Element**
 
 - https://ropsten.element.transmute.industries/
-- https://element.shellshop.lol/
 
 ## Developers Guide
 


### PR DESCRIPTION
Removes: https://element.shellshop.lol/ from node list. 